### PR TITLE
fix: use vendorCode tag for Matro feed article matching

### DIFF
--- a/price_parser/management/commands/setup_matroluxe_supplier_feed.py
+++ b/price_parser/management/commands/setup_matroluxe_supplier_feed.py
@@ -36,6 +36,11 @@ class Command(BaseCommand):
                 "match_by_article": True,
                 "match_by_name": True,
                 "is_active": True,
+                # Каталог Matro має N офферів (кольори) на один товар.
+                # <vendorCode> містить чистий артикул (наприклад, "53054-5"),
+                # <model> забруднено суфіксом кольору — тому використовуємо vendorCode.
+                "article_tag_name": "vendorCode",
+                "article_prefix_parts": 0,
             },
         )
 

--- a/price_parser/models.py
+++ b/price_parser/models.py
@@ -200,7 +200,7 @@ class SupplierFeedConfig(models.Model):
         verbose_name="XML тег артикулу",
         help_text=(
             "Назва XML-тегу, з якого читати артикул товару. "
-            "Для більшості фідів: 'model'. Для Vetro: 'article'."
+            "Для більшості фідів: 'model'. Для Vetro: 'article'. Для Matro: 'vendorCode'."
         )
     )
     article_prefix_parts = models.PositiveIntegerField(


### PR DESCRIPTION
Matro (Matroluxe) catalog has N offers per product (color variants), all sharing the same <vendorCode> (e.g. "53054-5"). The <model> tag appends the color name ("53054-5, Готові кольорові рішення Кашемір") which breaks article matching against furniture.article_code.

Set article_tag_name="vendorCode" in setup_matroluxe_supplier_feed so the parser reads the clean base article code directly. Also update models.py help_text to document this for future configs.