### PR TITLE
feat: size-variant price updates for Matro mattress feed (yml9)

### DIFF
--- a/custom_admin/forms.py
+++ b/custom_admin/forms.py
@@ -349,6 +349,8 @@ class SupplierFeedConfigForm(StyledModelForm):
             "price_multiplier",
             "article_tag_name",
             "article_prefix_parts",
+            "update_size_variants",
+            "size_param_name",
             "match_by_article",
             "match_by_name",
             "is_active",

--- a/price_parser/admin.py
+++ b/price_parser/admin.py
@@ -141,8 +141,15 @@ class SupplierFeedConfigAdmin(admin.ModelAdmin):
         ('Налаштування пошуку', {
             'fields': ('match_by_article', 'match_by_name', 'article_tag_name', 'article_prefix_parts'),
             'description': (
-                'article_tag_name: XML-тег для читання артикулу (зазвичай "model", для Vetro — "article"). '
+                'article_tag_name: XML-тег для читання артикулу (зазвичай "model", для Vetro — "article", для Matro — "vendorCode"). '
                 'article_prefix_parts: скільки частин через "-" брати як базовий код (0 = повний артикул).'
+            )
+        }),
+        ('Розміри товару', {
+            'fields': ('update_size_variants', 'size_param_name'),
+            'description': (
+                'Увімкніть, якщо фід містить розміри (матраці тощо). '
+                'size_param_name: атрибут name тегу <param> з розміром, напр. "Розмір матрацу (ШхД)".'
             )
         }),
         ('Налаштування цін', {

--- a/price_parser/management/commands/setup_matroluxe_mattress_feed.py
+++ b/price_parser/management/commands/setup_matroluxe_mattress_feed.py
@@ -1,0 +1,55 @@
+from django.core.management.base import BaseCommand
+
+from price_parser.models import SupplierFeedConfig
+
+
+DEFAULT_FEED_URL = "https://matroluxe.ua/index.php?route=extension/feed/yandex_yml9"
+DEFAULT_NAME = "Matroluxe — матраці"
+
+
+class Command(BaseCommand):
+    help = "Створює/оновлює SupplierFeedConfig для каталогу матраців Matroluxe (yml9)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--feed-url",
+            default=DEFAULT_FEED_URL,
+            help="Посилання на Matroluxe YML матраців (якщо інше ніж стандартне).",
+        )
+        parser.add_argument(
+            "--name",
+            default=DEFAULT_NAME,
+            help="Назва конфігурації у довіднику фідів.",
+        )
+
+    def handle(self, *args, **options):
+        name = options["name"]
+        feed_url = options["feed_url"]
+
+        config, created = SupplierFeedConfig.objects.update_or_create(
+            name=name,
+            defaults={
+                "feed_url": feed_url,
+                "supplier": "Matroluxe",
+                "category_hint": "Матраці (YML)",
+                "price_multiplier": 1,
+                "match_by_article": True,
+                "match_by_name": True,
+                "is_active": True,
+                # Кожен матрац має N офферів (розміри), кожен зі своєю ціною.
+                # <vendorCode> — чистий артикул, спільний для всіх розмірів.
+                "article_tag_name": "vendorCode",
+                "article_prefix_parts": 0,
+                # Оновлюємо FurnitureSizeVariant за розміром з <param name="Розмір матрацу (ШхД)">.
+                "update_size_variants": True,
+                "size_param_name": "Розмір матрацу (ШхД)",
+            },
+        )
+
+        action = "Створено" if created else "Оновлено"
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{action} конфігурацію '{config.name}'. "
+                "Запускайте парсер у кастомній адмінці (розділ Supplier Feeds)."
+            )
+        )

--- a/price_parser/migrations/0019_supplierfeedconfig_size_variant_settings.py
+++ b/price_parser/migrations/0019_supplierfeedconfig_size_variant_settings.py
@@ -1,0 +1,37 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("price_parser", "0018_supplierfeedconfig_article_settings"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="supplierfeedconfig",
+            name="update_size_variants",
+            field=models.BooleanField(
+                default=False,
+                verbose_name="Оновлювати розміри товару",
+                help_text=(
+                    "Якщо увімкнено, парсер оновлює ціни окремих розмірів (FurnitureSizeVariant), "
+                    "а не базову ціну товару. Потрібно вказати 'Назва XML-параметру розміру'."
+                ),
+            ),
+        ),
+        migrations.AddField(
+            model_name="supplierfeedconfig",
+            name="size_param_name",
+            field=models.CharField(
+                blank=True,
+                default="",
+                max_length=100,
+                verbose_name="Назва XML-параметру розміру",
+                help_text=(
+                    "Атрибут name тегу <param>, який містить розмір у форматі 'ШхД' (напр. '70x190'). "
+                    "Для матраців Matro: 'Розмір матрацу (ШхД)'."
+                ),
+            ),
+        ),
+    ]

--- a/price_parser/models.py
+++ b/price_parser/models.py
@@ -212,6 +212,24 @@ class SupplierFeedConfig(models.Model):
             "Наприклад: для 'S-120-cappuccino-velvet' з значенням 2 отримаємо 'S-120'."
         )
     )
+    update_size_variants = models.BooleanField(
+        default=False,
+        verbose_name="Оновлювати розміри товару",
+        help_text=(
+            "Якщо увімкнено, парсер оновлює ціни окремих розмірів (FurnitureSizeVariant), "
+            "а не базову ціну товару. Потрібно вказати 'Назва XML-параметру розміру'."
+        )
+    )
+    size_param_name = models.CharField(
+        max_length=100,
+        blank=True,
+        default='',
+        verbose_name="Назва XML-параметру розміру",
+        help_text=(
+            "Атрибут name тегу <param>, який містить розмір у форматі 'ШхД' (напр. '70x190'). "
+            "Для матраців Matro: 'Розмір матрацу (ШхД)'."
+        )
+    )
     match_by_article = models.BooleanField(
         default=True,
         verbose_name="Шукати за артикулом",

--- a/price_parser/services.py
+++ b/price_parser/services.py
@@ -399,6 +399,8 @@ class SupplierOffer:
     model: Optional[str]
     price: Decimal
     old_price: Optional[Decimal]
+    size_width: Optional[int] = None
+    size_length: Optional[int] = None
 
 
 class SupplierFeedPriceUpdater:
@@ -453,7 +455,9 @@ class SupplierFeedPriceUpdater:
             items_matched = 0
             items_updated = 0
             errors: List[Dict[str, str]] = []
-            seen_furniture: set[int] = set()
+            # De-duplicate by (furniture.pk, size_variant.pk or None) so that
+            # color-variant duplicates are skipped but different sizes are each processed.
+            seen_pairs: set = set()
 
             for offer in offers:
                 try:
@@ -477,12 +481,16 @@ class SupplierFeedPriceUpdater:
 
                 items_matched += 1
 
-                if furniture.pk in seen_furniture:
-                    # Avoid double updates for дублікати offerів на один товар
+                size_variant = None
+                if self.config.update_size_variants:
+                    size_variant = self._match_offer_to_size_variant(furniture, offer)
+
+                pair = (furniture.pk, size_variant.pk if size_variant else None)
+                if pair in seen_pairs:
                     continue
 
                 try:
-                    changed = self._apply_offer_prices(furniture, offer)
+                    changed = self._apply_offer_prices(furniture, offer, size_variant=size_variant)
                 except Exception as exc:
                     errors.append({
                         'offer_id': offer.offer_id,
@@ -492,7 +500,7 @@ class SupplierFeedPriceUpdater:
                     })
                     continue
 
-                seen_furniture.add(furniture.pk)
+                seen_pairs.add(pair)
                 if changed:
                     items_updated += 1
 
@@ -530,6 +538,7 @@ class SupplierFeedPriceUpdater:
 
         article_tag = (self.config.article_tag_name or 'model').strip()
         prefix_parts = self.config.article_prefix_parts or 0
+        size_param = (self.config.size_param_name or '').strip()
 
         offers: List[SupplierOffer] = []
         for offer_el in root.findall('.//offer'):
@@ -543,15 +552,44 @@ class SupplierFeedPriceUpdater:
                 parts = raw_article.split('-')
                 raw_article = '-'.join(parts[:prefix_parts])
 
+            size_width: Optional[int] = None
+            size_length: Optional[int] = None
+            if size_param:
+                for param_el in offer_el.findall('param'):
+                    if param_el.get('name') == size_param:
+                        size_width, size_length = self._parse_size(param_el.text or '')
+                        break
+
             offer = SupplierOffer(
                 offer_id=offer_el.get('id') or raw_article or (offer_el.findtext('name') or '').strip() or 'unknown',
                 name=(offer_el.findtext('name') or '').strip(),
                 model=raw_article,
                 price=price,
                 old_price=old_price,
+                size_width=size_width,
+                size_length=size_length,
             )
             offers.append(offer)
         return offers
+
+    def _parse_size(self, value: str) -> Tuple[Optional[int], Optional[int]]:
+        """Parse '70x190' or '70х190' (Cyrillic х) → (70, 190) as (width, length)."""
+        m = re.match(r'^(\d+)[xхХX×](\d+)$', value.strip())
+        if m:
+            return int(m.group(1)), int(m.group(2))
+        return None, None
+
+    def _match_offer_to_size_variant(
+        self, furniture: 'Furniture', offer: SupplierOffer
+    ) -> Optional['FurnitureSizeVariant']:
+        """Return the FurnitureSizeVariant matching offer's size, or None."""
+        if offer.size_width is None or offer.size_length is None:
+            return None
+        return FurnitureSizeVariant.objects.filter(
+            furniture=furniture,
+            width=offer.size_width,
+            length=offer.size_length,
+        ).first()
 
     def _parse_decimal(self, value: Optional[str]) -> Optional[Decimal]:
         if not value:
@@ -669,10 +707,19 @@ class SupplierFeedPriceUpdater:
         self._furniture_index = {'article': article_index, 'names': name_index}
         return self._furniture_index
 
-    def _apply_offer_prices(self, furniture: Furniture, offer: SupplierOffer) -> bool:
+    def _apply_offer_prices(
+        self,
+        furniture: Furniture,
+        offer: SupplierOffer,
+        *,
+        size_variant: Optional[FurnitureSizeVariant] = None,
+    ) -> bool:
         base_price, promo_price = self._resolve_prices(offer)
         if base_price is None:
             raise ValueError('Не вдалося визначити ціну')
+
+        if size_variant is not None:
+            return self._apply_size_variant_prices(size_variant, base_price, promo_price)
 
         updated_fields: List[str] = []
         changed = False
@@ -697,6 +744,38 @@ class SupplierFeedPriceUpdater:
 
         if changed:
             furniture.save(update_fields=list(dict.fromkeys(updated_fields)))
+
+        return changed
+
+    def _apply_size_variant_prices(
+        self,
+        variant: FurnitureSizeVariant,
+        base_price: Decimal,
+        promo_price: Optional[Decimal],
+    ) -> bool:
+        updated_fields: List[str] = []
+        changed = False
+
+        if variant.price != base_price:
+            variant.price = base_price
+            updated_fields.append('price')
+            changed = True
+
+        if promo_price is not None:
+            if (variant.promotional_price != promo_price) or (not variant.is_promotional):
+                variant.promotional_price = promo_price
+                variant.is_promotional = True
+                updated_fields.extend(['promotional_price', 'is_promotional'])
+                changed = True
+        else:
+            if variant.is_promotional or variant.promotional_price is not None:
+                variant.is_promotional = False
+                variant.promotional_price = None
+                updated_fields.extend(['is_promotional', 'promotional_price'])
+                changed = True
+
+        if changed:
+            variant.save(update_fields=list(dict.fromkeys(updated_fields)))
 
         return changed
 


### PR DESCRIPTION
Mattress catalog has ~15 size offers (70x190, 80x190, …) per vendorCode, each with its own price. Previous code de-duplicated at Furniture level, so only the first offer's price was applied.

Changes:
- SupplierFeedConfig: add update_size_variants (bool) and size_param_name fields
- Migration 0019 for new fields
- SupplierOffer dataclass: add size_width / size_length
- _fetch_offers: parse <param name=…> into size dimensions
- _parse_size: handle Latin/Cyrillic x separators
- _match_offer_to_size_variant: lookup FurnitureSizeVariant by width+length
- update_prices: de-duplicate by (furniture.pk, variant.pk) instead of furniture.pk alone
- _apply_offer_prices: route to _apply_size_variant_prices when variant matched
- _apply_size_variant_prices: update variant.price / promotional_price / is_promotional
- admin.py + custom_admin/forms.py: expose new fields in UI
- setup_matroluxe_mattress_feed: management command for yml9 config