### PR TITLE
feat: add Matroluxe sofa feed parser (yml7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,8 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ---
+## Робота з базою даних
+Викристовувати psycopg2
 
 ## Швидкі команди
 
@@ -22,6 +24,7 @@ Settings module: `store.settings`. Env змінні: `.env` в корені пр
 ---
 
 ## Документація в Obsidian
+Робити записи в Obsidian при зміні фіч та основних функцій.
 
 **Vault**: `~/Documents/Claude/Obsidian/montal home/`  
 **MCP сервер**: `obsidian-montal` (глобальний, завантажений автоматично)

--- a/price_parser/management/commands/setup_matroluxe_sofa_feed.py
+++ b/price_parser/management/commands/setup_matroluxe_sofa_feed.py
@@ -1,0 +1,56 @@
+from django.core.management.base import BaseCommand
+
+from price_parser.models import SupplierFeedConfig
+
+
+DEFAULT_FEED_URL = "https://matroluxe.ua/index.php?route=extension/feed/yandex_yml7"
+DEFAULT_NAME = "Matroluxe — дивани"
+
+
+class Command(BaseCommand):
+    help = "Створює/оновлює SupplierFeedConfig для каталогу диванів Matroluxe (yml7)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--feed-url",
+            default=DEFAULT_FEED_URL,
+            help="Посилання на Matroluxe YML диванів (якщо інше ніж стандартне).",
+        )
+        parser.add_argument(
+            "--name",
+            default=DEFAULT_NAME,
+            help="Назва конфігурації у довіднику фідів.",
+        )
+
+    def handle(self, *args, **options):
+        name = options["name"]
+        feed_url = options["feed_url"]
+
+        config, created = SupplierFeedConfig.objects.update_or_create(
+            name=name,
+            defaults={
+                "feed_url": feed_url,
+                "supplier": "Matroluxe",
+                "category_hint": "Дивани та ліжка (YML7)",
+                "price_multiplier": 1,
+                "match_by_article": True,
+                "match_by_name": True,
+                "is_active": True,
+                # Кожен офер відповідає одному товару (без варіантів розміру).
+                # <vendorCode> містить артикул товару (напр. "43271", "6508-21").
+                # <model> може містити суфікси кольору — тому читаємо vendorCode.
+                "article_tag_name": "vendorCode",
+                "article_prefix_parts": 0,
+                # Дивани не мають варіантів за розміром у цьому фіді.
+                "update_size_variants": False,
+                "size_param_name": "",
+            },
+        )
+
+        action = "Створено" if created else "Оновлено"
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{action} конфігурацію '{config.name}'. "
+                "Запускайте парсер у кастомній адмінці (розділ Supplier Feeds)."
+            )
+        )

--- a/price_parser/migrations/0001_initial.py
+++ b/price_parser/migrations/0001_initial.py
@@ -70,26 +70,4 @@ class Migration(migrations.Migration):
                 'unique_together': {('sheet_name', 'config')},
             },
         ),
-        migrations.CreateModel(
-            name='FurniturePriceCellMapping',
-            fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('sheet_row', models.PositiveIntegerField(help_text='Номер рядка в Google таблиці (наприклад: 5)', verbose_name='Рядок в таблиці')),
-                ('sheet_column', models.CharField(help_text='Колонка в Google таблиці (наприклад: E, F, G)', max_length=10, verbose_name='Колонка в таблиці')),
-                ('price_type', models.CharField(help_text='Опис типу ціни (наприклад: \'Стільниця стандарт\', \'HPL покриття\')', max_length=100, verbose_name='Тип ціни')),
-                ('is_active', models.BooleanField(default=True, verbose_name='Активне')),
-                ('created_at', models.DateTimeField(auto_now_add=True, verbose_name='Дата створення')),
-                ('updated_at', models.DateTimeField(auto_now=True, verbose_name='Дата оновлення')),
-                ('config', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='price_cell_mappings', to='price_parser.googlesheetconfig', verbose_name='Конфігурація Google таблиці')),
-                ('furniture', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='price_cell_mappings', to='furniture.furniture', verbose_name='Меблі')),
-                ('size_variant', models.ForeignKey(blank=True, help_text='Розмірний варіант для цієї ціни (опціонально)', null=True, on_delete=django.db.models.deletion.CASCADE, related_name='price_cell_mappings', to='furniture.furnituresizevariant', verbose_name='Розмірний варіант')),
-            ],
-            options={
-                'verbose_name': "Зв'язок меблів з коміркою ціни",
-                'verbose_name_plural': "Зв'язки меблів з комірками цін",
-                'db_table': 'price_parser_furniture_price_cell_mapping',
-                'ordering': ['furniture__name', 'sheet_row', 'sheet_column'],
-                'unique_together': {('furniture', 'config', 'sheet_row', 'sheet_column')},
-            },
-        ),
     ]

--- a/price_parser/tests.py
+++ b/price_parser/tests.py
@@ -1,0 +1,366 @@
+"""Tests for price_parser — SupplierFeedPriceUpdater (sofa/yml7 feed)."""
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from price_parser.services import SupplierFeedPriceUpdater, SupplierOffer
+
+
+# ---------------------------------------------------------------------------
+# Minimal YML XML fixture that mimics the matroluxe.ua/yml7 structure
+# ---------------------------------------------------------------------------
+
+SOFA_YML_FIXTURE = """<?xml version="1.0" encoding="UTF-8"?>
+<yml_catalog date="2024-01-01 12:00">
+  <shop>
+    <categories>
+      <category id="99883326">Дивани</category>
+      <category id="99883327">Ліжка</category>
+    </categories>
+    <offers>
+      <offer id="631" available="true">
+        <name>Диван кутовий Baltika</name>
+        <vendorCode>43271</vendorCode>
+        <price>25770</price>
+        <oldprice>27832</oldprice>
+        <categoryId>99883326</categoryId>
+      </offer>
+      <offer id="633" available="true">
+        <name>Диван Vesta двійка</name>
+        <vendorCode>88776</vendorCode>
+        <price>18606</price>
+        <oldprice>19722</oldprice>
+        <categoryId>99883326</categoryId>
+      </offer>
+      <offer id="708" available="true">
+        <name>Диван Magnolia</name>
+        <vendorCode>1-1-1-1</vendorCode>
+        <price>17547</price>
+        <categoryId>99883326</categoryId>
+      </offer>
+      <offer id="1052" available="true">
+        <name>Ліжко Beverly</name>
+        <vendorCode>57550</vendorCode>
+        <price>15470</price>
+        <categoryId>99883327</categoryId>
+        <param name="Бренд">Matro</param>
+        <param name="Гарантія">24 місяці</param>
+      </offer>
+      <offer id="9999" available="true">
+        <name>Товар без ціни</name>
+        <vendorCode>00000</vendorCode>
+        <categoryId>99883326</categoryId>
+      </offer>
+    </offers>
+  </shop>
+</yml_catalog>
+"""
+
+
+def _make_config(
+    article_tag_name="vendorCode",
+    article_prefix_parts=0,
+    update_size_variants=False,
+    size_param_name="",
+    price_multiplier=Decimal("1"),
+    match_by_article=True,
+    match_by_name=True,
+):
+    """Return a mock SupplierFeedConfig."""
+    cfg = MagicMock()
+    cfg.feed_url = "https://matroluxe.ua/index.php?route=extension/feed/yandex_yml7"
+    cfg.article_tag_name = article_tag_name
+    cfg.article_prefix_parts = article_prefix_parts
+    cfg.update_size_variants = update_size_variants
+    cfg.size_param_name = size_param_name
+    cfg.price_multiplier = price_multiplier
+    cfg.match_by_article = match_by_article
+    cfg.match_by_name = match_by_name
+    cfg.is_active = True
+    cfg.name = "Matroluxe — дивани"
+    return cfg
+
+
+class TestSupplierFeedFetchOffers(TestCase):
+    """Unit tests for _fetch_offers using a mocked HTTP response."""
+
+    def _make_updater(self, **kwargs):
+        cfg = _make_config(**kwargs)
+        updater = SupplierFeedPriceUpdater(cfg)
+        return updater
+
+    @patch("price_parser.services.requests.get")
+    def test_parses_offers_from_yml7_feed(self, mock_get):
+        mock_get.return_value.content = SOFA_YML_FIXTURE.encode("utf-8")
+        mock_get.return_value.raise_for_status = MagicMock()
+
+        updater = self._make_updater()
+        offers = updater._fetch_offers()
+
+        # Offer without <price> must be skipped → 4 valid offers
+        self.assertEqual(len(offers), 4)
+
+    @patch("price_parser.services.requests.get")
+    def test_vendor_code_read_correctly(self, mock_get):
+        mock_get.return_value.content = SOFA_YML_FIXTURE.encode("utf-8")
+        mock_get.return_value.raise_for_status = MagicMock()
+
+        updater = self._make_updater()
+        offers = updater._fetch_offers()
+
+        codes = [o.model for o in offers]
+        self.assertIn("43271", codes)
+        self.assertIn("88776", codes)
+        self.assertIn("1-1-1-1", codes)
+        self.assertIn("57550", codes)
+
+    @patch("price_parser.services.requests.get")
+    def test_price_and_oldprice_parsed(self, mock_get):
+        mock_get.return_value.content = SOFA_YML_FIXTURE.encode("utf-8")
+        mock_get.return_value.raise_for_status = MagicMock()
+
+        updater = self._make_updater()
+        offers = updater._fetch_offers()
+
+        baltika = next(o for o in offers if o.model == "43271")
+        self.assertEqual(baltika.price, Decimal("25770"))
+        self.assertEqual(baltika.old_price, Decimal("27832"))
+
+    @patch("price_parser.services.requests.get")
+    def test_offer_without_oldprice_has_none(self, mock_get):
+        mock_get.return_value.content = SOFA_YML_FIXTURE.encode("utf-8")
+        mock_get.return_value.raise_for_status = MagicMock()
+
+        updater = self._make_updater()
+        offers = updater._fetch_offers()
+
+        magnolia = next(o for o in offers if o.model == "1-1-1-1")
+        self.assertIsNone(magnolia.old_price)
+
+    @patch("price_parser.services.requests.get")
+    def test_no_size_variants_parsed_for_sofa_feed(self, mock_get):
+        mock_get.return_value.content = SOFA_YML_FIXTURE.encode("utf-8")
+        mock_get.return_value.raise_for_status = MagicMock()
+
+        updater = self._make_updater(update_size_variants=False, size_param_name="")
+        offers = updater._fetch_offers()
+
+        for offer in offers:
+            self.assertIsNone(offer.size_width)
+            self.assertIsNone(offer.size_length)
+
+
+class TestSupplierFeedResolvePrices(TestCase):
+    """Unit tests for _resolve_prices logic (old_price → base, price → promo)."""
+
+    def _updater(self):
+        return SupplierFeedPriceUpdater(_make_config())
+
+    def test_oldprice_becomes_base_price(self):
+        offer = SupplierOffer(
+            offer_id="631",
+            name="Диван Baltika",
+            model="43271",
+            price=Decimal("25770"),
+            old_price=Decimal("27832"),
+        )
+        updater = self._updater()
+        base, promo = updater._resolve_prices(offer)
+        self.assertEqual(base, Decimal("27832.00"))
+        self.assertEqual(promo, Decimal("25770.00"))
+
+    def test_no_oldprice_price_is_base(self):
+        offer = SupplierOffer(
+            offer_id="708",
+            name="Диван Magnolia",
+            model="1-1-1-1",
+            price=Decimal("17547"),
+            old_price=None,
+        )
+        updater = self._updater()
+        base, promo = updater._resolve_prices(offer)
+        self.assertEqual(base, Decimal("17547.00"))
+        self.assertIsNone(promo)
+
+    def test_multiplier_applied(self):
+        cfg = _make_config(price_multiplier=Decimal("1.1"))
+        offer = SupplierOffer(
+            offer_id="1",
+            name="Test",
+            model="X",
+            price=Decimal("10000"),
+            old_price=None,
+        )
+        updater = SupplierFeedPriceUpdater(cfg)
+        base, promo = updater._resolve_prices(offer)
+        self.assertEqual(base, Decimal("11000.00"))
+
+
+class TestSupplierFeedMatchOffer(TestCase):
+    """Tests for _match_offer_to_furniture using an in-memory furniture index."""
+
+    def _make_furniture(self, pk, name, article_code):
+        f = MagicMock()
+        f.pk = pk
+        f.id = pk
+        f.name = name
+        f.article_code = article_code
+        f.price = Decimal("1000")
+        f.promotional_price = None
+        f.is_promotional = False
+        return f
+
+    def _updater_with_index(self, furnitures):
+        updater = SupplierFeedPriceUpdater(_make_config())
+        # Build index manually instead of hitting the DB
+        article_index = {}
+        name_index = {}
+        for furn in furnitures:
+            if furn.article_code:
+                key = updater._normalize_article(furn.article_code)
+                article_index[key] = furn
+            for variant in updater._generate_name_variants(furn.name):
+                if variant:
+                    name_index.setdefault(variant, []).append(furn)
+        updater._furniture_index = {"article": article_index, "names": name_index}
+        return updater
+
+    def test_matches_by_vendor_code(self):
+        sofa = self._make_furniture(1, "Диван кутовий Baltika", "43271")
+        updater = self._updater_with_index([sofa])
+
+        offer = SupplierOffer(
+            offer_id="631",
+            name="Диван кутовий Baltika",
+            model="43271",
+            price=Decimal("25770"),
+            old_price=Decimal("27832"),
+        )
+        result = updater._match_offer_to_furniture(offer)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.pk, 1)
+
+    def test_matches_by_name_fallback(self):
+        sofa = self._make_furniture(2, "Диван Magnolia", None)
+        updater = self._updater_with_index([sofa])
+
+        offer = SupplierOffer(
+            offer_id="708",
+            name="Диван Magnolia",
+            model=None,
+            price=Decimal("17547"),
+            old_price=None,
+        )
+        result = updater._match_offer_to_furniture(offer)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.pk, 2)
+
+    def test_no_match_returns_none(self):
+        sofa = self._make_furniture(3, "Диван Jersey", "47931")
+        updater = self._updater_with_index([sofa])
+
+        offer = SupplierOffer(
+            offer_id="999",
+            name="Диван Невідомий",
+            model="99999",
+            price=Decimal("5000"),
+            old_price=None,
+        )
+        result = updater._match_offer_to_furniture(offer)
+        self.assertIsNone(result)
+
+    def test_article_code_with_dashes_matches(self):
+        sofa = self._make_furniture(4, "Диван Chelsi", "6508-21")
+        updater = self._updater_with_index([sofa])
+
+        offer = SupplierOffer(
+            offer_id="1561",
+            name="Диван Chelsi",
+            model="6508-21",
+            price=Decimal("26054"),
+            old_price=None,
+        )
+        result = updater._match_offer_to_furniture(offer)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.pk, 4)
+
+
+class TestSupplierFeedApplyPrices(TestCase):
+    """Tests for _apply_offer_prices — verifies DB save calls and field changes."""
+
+    def _make_furniture(self, price=Decimal("20000"), promo=None, is_promo=False):
+        f = MagicMock()
+        f.pk = 1
+        f.price = price
+        f.promotional_price = promo
+        f.is_promotional = is_promo
+        return f
+
+    def _updater(self):
+        return SupplierFeedPriceUpdater(_make_config())
+
+    def test_updates_base_price(self):
+        furniture = self._make_furniture(price=Decimal("20000"))
+        offer = SupplierOffer(
+            offer_id="1",
+            name="Test",
+            model="X",
+            price=Decimal("18000"),
+            old_price=None,
+        )
+        updater = self._updater()
+        changed = updater._apply_offer_prices(furniture, offer)
+        self.assertTrue(changed)
+        self.assertEqual(furniture.price, Decimal("18000.00"))
+        furniture.save.assert_called_once()
+
+    def test_sets_promotional_price_when_oldprice_present(self):
+        furniture = self._make_furniture(price=Decimal("27832"))
+        offer = SupplierOffer(
+            offer_id="631",
+            name="Диван Baltika",
+            model="43271",
+            price=Decimal("25770"),
+            old_price=Decimal("27832"),
+        )
+        updater = self._updater()
+        changed = updater._apply_offer_prices(furniture, offer)
+        self.assertTrue(changed)
+        self.assertEqual(furniture.promotional_price, Decimal("25770.00"))
+        self.assertTrue(furniture.is_promotional)
+
+    def test_clears_promo_when_no_oldprice(self):
+        furniture = self._make_furniture(
+            price=Decimal("17547"),
+            promo=Decimal("15000"),
+            is_promo=True,
+        )
+        offer = SupplierOffer(
+            offer_id="708",
+            name="Диван Magnolia",
+            model="1-1-1-1",
+            price=Decimal("17547"),
+            old_price=None,
+        )
+        updater = self._updater()
+        # price unchanged but promo must be cleared
+        furniture.price = Decimal("17547.00")  # already set to match
+        changed = updater._apply_offer_prices(furniture, offer)
+        self.assertTrue(changed)
+        self.assertFalse(furniture.is_promotional)
+        self.assertIsNone(furniture.promotional_price)
+
+    def test_no_change_when_prices_equal(self):
+        furniture = self._make_furniture(price=Decimal("17547.00"))
+        offer = SupplierOffer(
+            offer_id="708",
+            name="Диван Magnolia",
+            model="1-1-1-1",
+            price=Decimal("17547"),
+            old_price=None,
+        )
+        updater = self._updater()
+        changed = updater._apply_offer_prices(furniture, offer)
+        self.assertFalse(changed)
+        furniture.save.assert_not_called()


### PR DESCRIPTION
- Add setup_matroluxe_sofa_feed management command for yml7 feed (Дивани та ліжка, vendorCode matching, no size variants)
- Add price_parser/tests.py with 16 unit tests covering: offer parsing, price/promo resolution, article matching, apply prices
- Fix 0001_initial migration: remove duplicate FurniturePriceCellMapping definition (it's already created by 0002_furniturepricecellmapping)