### PR TITLE
feat: management commands for description reformatting and parameter …

### DIFF
--- a/custom_admin/templates/custom_admin/list.html
+++ b/custom_admin/templates/custom_admin/list.html
@@ -85,9 +85,9 @@
 {% elif furniture_bulk_edit_url %}
 <form method="post" action="{{ furniture_bulk_edit_url }}" id="furniture-bulk-form" class="space-y-4">
     {% csrf_token %}
-    <div id="furniture-bulk-bar" class="hidden bg-white border border-beige-300 rounded-xl shadow-sm p-4 flex items-center justify-between">
+    <div id="furniture-bulk-bar" style="display:none" class="bg-white border border-beige-300 rounded-xl shadow-sm p-4 items-center justify-between gap-3">
         <span class="text-brown-700 font-medium">Вибрано: <span id="furniture-selected-count">0</span></span>
-        <button type="submit" class="inline-flex items-center px-4 py-2 bg-brown-600 text-white rounded-md hover:bg-brown-700 focus:outline-none focus:ring-2 focus:ring-brown-500 focus:ring-offset-2">
+        <button type="submit" class="inline-flex items-center px-4 py-2 bg-brown-600 text-white rounded-md hover:bg-brown-700 focus:outline-none focus:ring-2 focus:ring-brown-500 focus:ring-offset-2 whitespace-nowrap">
             <i class="fa-solid fa-pen-to-square mr-2"></i> Масове редагування
         </button>
     </div>
@@ -213,11 +213,7 @@
         function updateBar() {
             const checked = document.querySelectorAll('.furniture-checkbox:checked').length;
             countEl.textContent = checked;
-            if (checked > 0) {
-                bulkBar.classList.remove('hidden');
-            } else {
-                bulkBar.classList.add('hidden');
-            }
+            bulkBar.style.display = checked > 0 ? 'flex' : 'none';
         }
 
         if (selectAll) {

--- a/furniture/management/commands/cleanup_parameters.py
+++ b/furniture/management/commands/cleanup_parameters.py
@@ -1,0 +1,150 @@
+"""
+Management command:
+  1. Видаляє параметри-виробники (торгова марка, бренд, виробник тощо),
+     крім «країна виробник».
+  2. Нормалізує одиниці вимірювання розмірів: приводить значення до сантиметрів.
+     Значення > 300 вважається міліметрами (типові розміри меблів: 40–300 см).
+  3. Нормалізує розділювач у розмірних значеннях: *, х (кирилиця), X → x.
+     Наприклад: «100*120» або «100х120» → «100x120».
+"""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal, InvalidOperation
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from params.models import FurnitureParameter, Parameter
+
+# Паттерн: label містить щось із цього списку → параметр-виробник → видаляємо
+MANUFACTURER_RE = re.compile(
+    r"(торгова\s*марка|торг[\.\s]марка|бренд|brand|виробник|manufacturer|фабрика|"
+    r"постачальник|supplier|марка\s*(матрацу|меблів|товару|бренду)?)",
+    re.IGNORECASE,
+)
+# Виняток: якщо label містить це — НЕ видаляємо
+MANUFACTURER_KEEP_RE = re.compile(r"країна", re.IGNORECASE)
+
+DIMENSION_KEYS = {"width_cm", "height_cm", "depth_cm"}
+# Параметри, що можуть містити композитний формат типу «100x200»
+DIMENSION_LABEL_RE = re.compile(
+    r"(ширин|висот|глибин|розмір|габарит|довжин)", re.IGNORECASE
+)
+MM_THRESHOLD = Decimal("300")  # вище — точно мм, нижче — вже см
+# Усі варіанти розділювача між числами у розмірі
+SEPARATOR_RE = re.compile(r"[*×хХxX\s]+")  # * × х(кир) Х(кир) x X пробіл
+
+
+class Command(BaseCommand):
+    help = "Видаляє 'Торгова марка' та нормалізує одиниці/формат розмірів"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Показати що буде зроблено, без змін у БД",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        if dry_run:
+            self.stdout.write(self.style.WARNING("=== DRY RUN — БД не змінюється ==="))
+
+        with transaction.atomic():
+            self._delete_manufacturer_params(dry_run)
+            self._normalize_dimensions(dry_run)
+
+            if dry_run:
+                transaction.set_rollback(True)
+
+        self.stdout.write(self.style.SUCCESS("Готово."))
+
+    # ------------------------------------------------------------------
+    def _delete_manufacturer_params(self, dry_run: bool) -> None:
+        """Видаляє параметри-виробники (бренд, торгова марка, виробник…),
+        але зберігає «Країна виробник» та подібні."""
+        candidates = [
+            p for p in Parameter.objects.all()
+            if MANUFACTURER_RE.search(p.label) and not MANUFACTURER_KEEP_RE.search(p.label)
+        ]
+
+        if not candidates:
+            self.stdout.write("Параметри-виробники — не знайдено.")
+            return
+
+        self.stdout.write(f"Параметри-виробники до видалення ({len(candidates)}):")
+        for param in candidates:
+            fp_count = FurnitureParameter.objects.filter(parameter=param).count()
+            self.stdout.write(
+                f"  id={param.id} '{param.label}' (key={param.key}): {fp_count} прив'язок"
+            )
+            if not dry_run:
+                FurnitureParameter.objects.filter(parameter=param).delete()
+                param.delete()
+
+    # ------------------------------------------------------------------
+    def _normalize_dimensions(self, dry_run: bool) -> None:
+        # Обробляємо і стандартні ключі, і параметри з «розмір» у мітці
+        dim_params = Parameter.objects.filter(key__in=DIMENSION_KEYS)
+        label_params = Parameter.objects.filter(label__iregex=DIMENSION_LABEL_RE.pattern)
+        params = (dim_params | label_params).distinct()
+
+        if not params.exists():
+            self.stdout.write("Розмірні параметри не знайдено.")
+            return
+
+        total_fixed = 0
+        for param in params:
+            for fp in FurnitureParameter.objects.filter(parameter=param):
+                new_val = self._normalize_value(fp.value)
+                if new_val != fp.value:
+                    self.stdout.write(
+                        f"  {param.key}: furniture_id={fp.furniture_id} "
+                        f"'{fp.value}' → '{new_val}'"
+                    )
+                    if not dry_run:
+                        fp.value = new_val
+                        fp.save(update_fields=["value"])
+                    total_fixed += 1
+
+        self.stdout.write(f"Розміри: виправлено {total_fixed} значень.")
+
+    # ------------------------------------------------------------------
+    def _normalize_value(self, raw: str) -> str:
+        """
+        Нормалізує одне значення параметра:
+        - прибирає суфікси одиниць (мм, см, mm, cm)
+        - конвертує мм → см якщо > 300
+        - нормалізує розділювач між числами → x
+        """
+        stripped = raw.strip()
+
+        # Розбиваємо на частини за будь-яким розділювачем
+        # Спочатку прибираємо одиниці вимірювання з усього рядка
+        cleaned = re.sub(r"\s*(мм|mm|см|cm)\s*", "", stripped, flags=re.IGNORECASE).strip()
+
+        # Перевіряємо чи є розділювач (композитне значення)
+        parts = SEPARATOR_RE.split(cleaned)
+        parts = [p.strip() for p in parts if p.strip()]
+
+        if not parts:
+            return raw
+
+        converted = []
+        for part in parts:
+            try:
+                val = Decimal(part)
+            except InvalidOperation:
+                # не числова частина — повертаємо оригінал без змін
+                return raw
+            if val > MM_THRESHOLD:
+                val = (val / Decimal("10")).normalize()
+            else:
+                val = val.normalize()
+            converted.append(format(val, "f"))
+
+        result = "x".join(converted)
+        return result
+

--- a/furniture/management/commands/deduplicate_parameters.py
+++ b/furniture/management/commands/deduplicate_parameters.py
@@ -1,0 +1,218 @@
+"""
+Management command: дедублікація та нормалізація ключів параметрів.
+
+Крок 1 — Дедублікація:
+  Параметри з однаковою міткою (після нормалізації пунктуації та регістру)
+  об'єднуються. Канонічний — той з меншим id (найстаріший). Всі FurnitureParameter
+  і SubCategory.allowed_params переводяться на канонічний, дублікати видаляються.
+
+  Нормалізація label для порівняння: "Ширина, см" == "Ширина (см)" == "ширина см"
+
+Крок 2 — Нормалізація ключів:
+  Параметри з некрасивим ключем (param_XXXX) що ЗАЛИШИЛИСЬ після кроку 1
+  перейменовуються через транслітерацію label → ASCII slug.
+  Якщо slug вже зайнятий — параметр пропускається з попередженням.
+
+Запуск:
+    python manage.py deduplicate_parameters --dry-run
+    python manage.py deduplicate_parameters
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from params.models import FurnitureParameter, Parameter
+from sub_categories.models import SubCategory
+
+# ---------------------------------------------------------------------------
+# Транслітерація українських літер → латиниця
+# ---------------------------------------------------------------------------
+_UA_MAP = {
+    "а": "a", "б": "b", "в": "v", "г": "h", "ґ": "g", "д": "d",
+    "е": "e", "є": "ye", "ж": "zh", "з": "z", "и": "y", "і": "i",
+    "ї": "yi", "й": "y", "к": "k", "л": "l", "м": "m", "н": "n",
+    "о": "o", "п": "p", "р": "r", "с": "s", "т": "t", "у": "u",
+    "ф": "f", "х": "kh", "ц": "ts", "ч": "ch", "ш": "sh", "щ": "shch",
+    "ь": "", "ю": "yu", "я": "ya",
+}
+
+
+def _slugify_label(label: str) -> str:
+    result = []
+    for ch in label.lower():
+        if ch in _UA_MAP:
+            result.append(_UA_MAP[ch])
+        elif ch.isascii() and (ch.isalnum() or ch in "-_ "):
+            result.append(ch)
+        else:
+            result.append("_")
+    slug = re.sub(r"[\s\-]+", "_", "".join(result))
+    slug = re.sub(r"_+", "_", slug).strip("_")
+    return slug[:80]
+
+
+_UNIT_SUFFIXES = re.compile(
+    r"\b(см|мм|cm|mm|кг|kg|г|м\b|m\b|шт|л|inch|дюйм)\b", re.IGNORECASE
+)
+
+
+def _normalize_label(label: str) -> str:
+    """
+    Нормалізує мітку для порівняння:
+      - lowercase
+      - прибирає пунктуацію (,  .  ()  []  {} /)
+      - прибирає одиниці вимірювання (см, мм, кг, …)
+      - нормалізує пробіли
+
+    "Максимальна висота, см" → "максимальна висота"
+    "Максимальна висота"     → "максимальна висота"  → збіг!
+    "Ширина (см)"            → "ширина"
+    "Ширина, мм"             → "ширина"              → збіг!
+    """
+    text = label.lower()
+    text = re.sub(r"[,.()\[\]{}/\\]", " ", text)
+    text = _UNIT_SUFFIXES.sub(" ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+class Command(BaseCommand):
+    help = "Дедублікує параметри за label, нормалізує ключі param_XXXX → slug"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--dry-run", action="store_true")
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        if dry_run:
+            self.stdout.write(self.style.WARNING("=== DRY RUN — БД не змінюється ===\n"))
+
+        with transaction.atomic():
+            # ids параметрів що будуть видалені — step2 їх пропускає
+            to_delete_ids: set[int] = self._step1_deduplicate(dry_run)
+            self._step2_normalize_keys(dry_run, skip_ids=to_delete_ids)
+
+            if dry_run:
+                transaction.set_rollback(True)
+
+        self.stdout.write(self.style.SUCCESS("\nГотово."))
+
+    # ------------------------------------------------------------------
+    def _step1_deduplicate(self, dry_run: bool) -> set[int]:
+        """Повертає set id параметрів що будуть/були видалені."""
+        self.stdout.write(self.style.HTTP_INFO("── Крок 1: дедублікація ──"))
+
+        groups: dict[str, list[Parameter]] = defaultdict(list)
+        for p in Parameter.objects.all().order_by("id"):
+            groups[_normalize_label(p.label)].append(p)
+
+        duplicates = {k: v for k, v in groups.items() if len(v) > 1}
+
+        if not duplicates:
+            self.stdout.write("  Дублікатів не знайдено.\n")
+            return set()
+
+        to_delete: set[int] = set()
+        merged = fp_moved = sc_updated = 0
+
+        for norm_label, params in sorted(duplicates.items()):
+            canonical = params[0]   # найменший id = найстаріший
+            others = params[1:]
+
+            self.stdout.write(
+                f"\n  [{norm_label}]\n"
+                f"    Канонічний : id={canonical.id}  key={canonical.key!r}  label='{canonical.label}'\n"
+                f"    Дублікати  : " +
+                "  |  ".join(f"id={p.id} key={p.key!r} label='{p.label}'" for p in others)
+            )
+
+            for dup in others:
+                to_delete.add(dup.id)
+
+                for fp in FurnitureParameter.objects.filter(parameter=dup):
+                    conflict = FurnitureParameter.objects.filter(
+                        furniture_id=fp.furniture_id, parameter=canonical
+                    ).first()
+                    if conflict:
+                        self.stdout.write(
+                            f"      furniture_id={fp.furniture_id}: конфлікт — "
+                            f"залишаємо '{conflict.value}', видаляємо '{fp.value}'"
+                        )
+                        if not dry_run:
+                            fp.delete()
+                    else:
+                        self.stdout.write(
+                            f"      furniture_id={fp.furniture_id}: переносимо '{fp.value}'"
+                        )
+                        if not dry_run:
+                            fp.parameter = canonical
+                            fp.save(update_fields=["parameter"])
+                        fp_moved += 1
+
+                for sc in SubCategory.objects.filter(allowed_params=dup):
+                    self.stdout.write(f"      SubCategory '{sc.name}': оновлюємо allowed_params")
+                    if not dry_run:
+                        sc.allowed_params.remove(dup)
+                        if not sc.allowed_params.filter(id=canonical.id).exists():
+                            sc.allowed_params.add(canonical)
+                    sc_updated += 1
+
+                if not dry_run:
+                    dup.delete()
+                merged += 1
+
+        self.stdout.write(
+            f"\n  Результат: видалено {merged} дублікатів, "
+            f"перенесено {fp_moved} прив'язок, оновлено {sc_updated} підкатегорій."
+        )
+        return to_delete
+
+    # ------------------------------------------------------------------
+    def _step2_normalize_keys(self, dry_run: bool, skip_ids: set[int]) -> None:
+        self.stdout.write(self.style.HTTP_INFO("\n── Крок 2: нормалізація ключів ──"))
+
+        ugly = Parameter.objects.filter(key__regex=r"^param_[0-9]+$").exclude(id__in=skip_ids)
+        if not ugly.exists():
+            self.stdout.write("  Некрасивих ключів не знайдено.")
+            return
+
+        # Ключі що вже зайняті після кроку 1 (без видалених дублікатів)
+        taken_keys: set[str] = set(
+            Parameter.objects.exclude(id__in=skip_ids).values_list("key", flat=True)
+        )
+
+        renamed = skipped = 0
+        for param in ugly.order_by("id"):
+            new_key = _slugify_label(param.label)
+
+            if not new_key:
+                self.stdout.write(
+                    self.style.WARNING(f"  id={param.id} '{param.label}': slug порожній, пропускаємо")
+                )
+                skipped += 1
+                continue
+
+            if new_key in taken_keys and new_key != param.key:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  id={param.id} '{param.label}': slug '{new_key}' вже зайнятий, пропускаємо"
+                    )
+                )
+                skipped += 1
+                continue
+
+            self.stdout.write(f"  id={param.id} '{param.label}': {param.key!r} → {new_key!r}")
+            if not dry_run:
+                taken_keys.discard(param.key)
+                param.key = new_key
+                param.save(update_fields=["key"])
+                taken_keys.add(new_key)
+            else:
+                taken_keys.add(new_key)  # резервуємо в dry-run щоб не дублювати
+            renamed += 1
+
+        self.stdout.write(f"\n  Результат: перейменовано {renamed}, пропущено {skipped}.")

--- a/furniture/management/commands/reformat_bed_descriptions.py
+++ b/furniture/management/commands/reformat_bed_descriptions.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import re
+
+from django.core.management.base import BaseCommand
+
+from furniture.models import Furniture
+
+
+ADVANTAGES_HEADER_RE = re.compile(
+    r'(?:'
+    r'(?:Модель|Ліжко[^\n]{0,40}?)\s+має\s+(?:наступні\s+|масу\s+|такі\s+)?переваги|'
+    r'Переваги моделі|'
+    r'Особливості моделі|'
+    r'Характеристики та переваги[^:\n]*:?|'
+    r'Також\s+(?:виріб|модель)\s+має\s+такі\s+переваги|'
+    r'Інші(?:\s+його)?\s+переваги(?:\s+виробу)?|'
+    r'[\.!?]\s*переваги(?:\s+моделі)?'   # "...інтер'єр.переваги моделі:" — після крапки
+    r')\s*:?',
+    re.IGNORECASE,
+)
+
+REMOVE_SECTIONS: list[re.Pattern] = [
+    # Characteristics block: remove until advantages header or end
+    re.compile(
+        r'Характеристики\s*:.*?'
+        r'(?=Модель має|Також\s+(?:виріб|модель)|Інші\s+(?:його\s+)?переваги|Переваги моделі|Особливості моделі|$)',
+        re.DOTALL | re.IGNORECASE,
+    ),
+    # Materials section: remove to end (Використовувані / Використовані / Використані)
+    re.compile(r'Використ(?:овувані|овані|ані) матеріали.*$', re.DOTALL | re.IGNORECASE),
+    # Buying / promo section: remove to end
+    re.compile(r'Переваги покупки.*$', re.DOTALL | re.IGNORECASE),
+    re.compile(r'Купити ліжко.*$', re.DOTALL | re.IGNORECASE),
+    # Manufacturer disclaimer: remove to end
+    re.compile(r'\*?\s*Виробник залишає за собою право.*$', re.DOTALL | re.IGNORECASE),
+    # "Увага! Матрац в комплект не входить..." — remove sentence
+    re.compile(r'Увага!\s*Матрац[^\.]+\.', re.IGNORECASE),
+    # LUXE STUDIO promo block (first 2 sentences)
+    re.compile(r'LUXE STUDIO.*?(?=Ліжко|Диван|Крісло|$)', re.DOTALL | re.IGNORECASE),
+    # Generic "using our technology we produce..." company intro sentence
+    re.compile(r'Використовуючи новітні технології[^\.]+\.', re.IGNORECASE),
+    # "Детальніше про модель" section with specs
+    re.compile(r'Детальніше про модель.*?(?=\n\n|Основні|$)', re.DOTALL | re.IGNORECASE),
+    # "Розміри:" specs block
+    re.compile(r'Розміри\s*:.*?(?=\n\n|$)', re.DOTALL | re.IGNORECASE),
+    # "Основні" leftover label
+    re.compile(r'^Основні\s*$', re.MULTILINE | re.IGNORECASE),
+    # Leftover hardware specs line (e.g. "Люстерко. Ручка меблева...")
+    re.compile(r'Люстерко\.[^\n]*', re.IGNORECASE),
+    # "Підібрати ортопедичний матрац ... можна ТУТ"
+    re.compile(r'Підібрати ортопедичний матрац[^\.]*\.?', re.IGNORECASE),
+]
+
+BRAND_SUBS: list[tuple[re.Pattern, str]] = [
+    # "На сайті Matroluxe/Matro/etc [будь-що]." — тільки на початку речення (велика "Н")
+    (
+        re.compile(r'На сайті\s+\S*(?:Matrolux[e]?|Matro|Матролюкс|Матро)\S*[^\.]*\.'),
+        '',
+    ),
+    # "Зверніть увагу на новинку від торгової марки Sofyno — "
+    (
+        re.compile(
+            r'Зверніть увагу на новинку від\s+(?:торгової марки\s+)?'
+            r'(?:Sofyno|Matrolux[e]?|Матролюкс)\s*[—–]\s*',
+            re.IGNORECASE,
+        ),
+        '',
+    ),
+    # "Торгова марка Sofyno представляє до вашої уваги новинку — "
+    (re.compile(r'Торгова марка\s+Sofyno\s+[^—–]+[—–]\s*', re.IGNORECASE), ''),
+    # " ТМ Sofyno" / "торгової марки Sofyno" — видалити, зберегти подальший роздільник
+    (re.compile(r'\s+(?:ТМ|торгової марки)\s+Sofyno', re.IGNORECASE), ''),
+    # "на сайті Matro..." всередині речення
+    (re.compile(r'на сайті\s+\S*(?:matro|матро|matrolux)\S*\s*', re.IGNORECASE), ''),
+    # "в інтернет-магазині ..."
+    (re.compile(r'в інтернет-магазині\s+\S+', re.IGNORECASE), ''),
+    # Leftover "від виробника" after brand removal
+    (re.compile(r'\s+від виробника\b', re.IGNORECASE), ''),
+    # Leftover "які представлені" (fragment after mid-sentence brand removal)
+    (re.compile(r',?\s*які представлені\s*', re.IGNORECASE), ''),
+    # Standalone brand tokens
+    (re.compile(r'\bMatrolux[e]?\b', re.IGNORECASE), ''),
+    (re.compile(r'\bMatro\b', re.IGNORECASE), ''),
+    (re.compile(r'\bSofyno\b', re.IGNORECASE), ''),
+    (re.compile(r'\bМатролюкс\b'), ''),
+    (re.compile(r'\bматро\b', re.IGNORECASE), ''),
+    (re.compile(r'\bсофіно\b', re.IGNORECASE), ''),
+]
+
+
+def _strip_title_header(text: str) -> str:
+    """Remove leading 'Переваги [model name][:][newline]' header."""
+    # With colon + newline
+    m = re.match(r'^Переваги[^\r\n:]{1,120}:\s*\r?\n', text)
+    if m:
+        return text[m.end():]
+    # With just newline
+    m = re.match(r'^Переваги[^\r\n]{1,120}\r?\n', text)
+    if m:
+        return text[m.end():]
+    # Concatenated: detect lowercase→uppercase boundary (Cyrillic or Latin→Cyrillic)
+    m = re.match(r'^Переваги\s+\S+(?:\s+\S+){0,12}?[а-яіїєa-z](?=[А-ЯІЇЄ])', text)
+    if m:
+        return text[m.end():]
+    # Fallback: remove up to first colon
+    m = re.match(r'^Переваги[^:]{1,120}:\s*', text)
+    if m:
+        return text[m.end():]
+    return text
+
+
+def _clean_whitespace(text: str) -> str:
+    text = text.replace('\r\n', '\n').replace('\r', '\n')
+    text = re.sub(r'[ \t]+', ' ', text)
+    text = re.sub(r' \.', '.', text)        # "слово ." → "слово."
+    text = re.sub(r'\n{3,}', '\n\n', text)
+    return text.strip()
+
+
+def _split_list_items(raw: str) -> list[str]:
+    """Split 'Item1.Item2.' or 'Item1;Item2;' into list items."""
+    items = []
+    for chunk in re.split(r'[\.;]\s*\n?', raw):
+        chunk = chunk.strip()
+        if len(chunk) > 4:
+            items.append(chunk)
+    return items
+
+
+def _clean_name(name: str) -> str:
+    """Remove dimensions and normalize slashes in furniture name."""
+    name = re.sub(r'\s*\(\d+[хx×]\d+(?:[/\d хx×]*)\)\s*$', '', name).strip()
+    name = re.sub(r'\s*/\s*', ' / ', name)
+    return re.sub(r'\s+', ' ', name).strip()
+
+
+def format_bed_description(raw: str, furniture_name: str) -> str:
+    text = raw.strip()
+
+    # Skip already-formatted HTML (more than one tag)
+    if text.count('<') > 2:
+        return raw
+
+    # 1. Strip title header
+    text = _strip_title_header(text)
+
+    # 2. Remove unwanted sections
+    for pattern in REMOVE_SECTIONS:
+        text = pattern.sub('', text)
+
+    # 3. Remove brand mentions
+    for pattern, replacement in BRAND_SUBS:
+        text = pattern.sub(replacement, text)
+
+    text = _clean_whitespace(text)
+
+    # Capitalize first letter after all removals
+    if text and text[0].islower():
+        text = text[0].upper() + text[1:]
+
+    # 4. Split intro vs advantages list
+    adv_match = ADVANTAGES_HEADER_RE.search(text)
+    if adv_match:
+        intro_raw = text[: adv_match.start()].strip()
+        adv_raw = text[adv_match.end():].strip()
+    else:
+        intro_raw = text
+        adv_raw = ''
+
+    # 5. Build intro HTML
+    paragraphs = [p.strip() for p in re.split(r'\n\n', intro_raw) if p.strip()]
+    intro_html = ''.join(f'<p>{p}</p>' for p in paragraphs) if paragraphs else ''
+
+    # 6. Build advantages HTML
+    adv_html = ''
+    if adv_raw:
+        items = _split_list_items(adv_raw)
+        if items:
+            items_html = ''.join(f'<li>{item}.</li>' for item in items)
+            adv_html = f'<h3>Переваги:</h3><ul>{items_html}</ul>'
+
+    # 7. Compose final HTML
+    h2 = _clean_name(furniture_name)
+    return f'<h2>{h2}</h2>{intro_html}{adv_html}'
+
+
+class Command(BaseCommand):
+    help = "Переформатовує описи ліжок: видаляє бренди/характеристики, додає HTML структуру."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Показати результат без збереження в БД.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=None,
+            help="Обробити лише N ліжок (для тесту).",
+        )
+        parser.add_argument(
+            "--verbose",
+            action="store_true",
+            help="Виводити кожен результат.",
+        )
+
+    def handle(self, *args, **options):
+        dry_run: bool = options["dry_run"]
+        limit: int | None = options["limit"]
+        verbose: bool = options["verbose"]
+
+        qs = (
+            Furniture.objects.filter(sub_category__category__name="Ліжка")
+            .exclude(description="")
+            .select_related("sub_category__category")
+        )
+
+        if limit:
+            qs = qs[:limit]
+
+        updated = skipped = 0
+        for bed in qs.iterator(chunk_size=50):
+            new_desc = format_bed_description(bed.description, bed.name)
+            if new_desc == bed.description:
+                skipped += 1
+                continue
+
+            updated += 1
+            if verbose:
+                self.stdout.write(f"\n{'='*60}")
+                self.stdout.write(f"ID {bed.id} | {bed.name}")
+                self.stdout.write(new_desc)
+
+            if not dry_run:
+                bed.description = new_desc
+                bed.save(update_fields=["description"])
+
+        tag = "DRY-RUN" if dry_run else "DONE"
+        self.stdout.write(
+            self.style.SUCCESS(f"[{tag}] Оновлено: {updated}, без змін: {skipped}.")
+        )

--- a/furniture/management/commands/reformat_mattress_descriptions.py
+++ b/furniture/management/commands/reformat_mattress_descriptions.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import re
+
+from django.core.management.base import BaseCommand
+
+from furniture.models import Furniture
+
+
+ADVANTAGES_HEADER_RE = re.compile(
+    r'(?:'
+    r'Чому варто обрати[^\n:]{0,40}:?|'
+    r'(?:Модель|Матрац[^\n]{0,40}?)\s+(?:має|володіє)[^\n]{0,30}?переваг(?:и|ами)?|'
+    r'(?:А\s+)?[Тт]акож\s+(?:виріб|матрац|модель)\s+має\s+(?:такі|наступні)\s+переваг(?:и|ами)?|'
+    r'(?:А\s+)?[Тт]акож\s+матрац\s+має\s+(?:такі|наступні)\s+переваг(?:и|ами)?|'
+    r'А\s+також\s+має\s+(?:наступні|такі)\s+переваг(?:и|ами)?|'
+    r'Переваги моделі|'
+    r'Інші(?:\s+його)?\s+переваг(?:и|ами)?(?:\s+виробу)?|'
+    r'[\.!?]\s*переваг(?:и|ами)?(?:\s+моделі)?'
+    r')\s*:?',
+    re.IGNORECASE,
+)
+
+REMOVE_SECTIONS: list[re.Pattern] = [
+    # Characteristics block
+    re.compile(
+        r'(?:Основні\s+)?Характеристики\s*:.*?'
+        r'(?=Чому варто|Також\s+(?:виріб|матрац)|Інші\s+переваг(?:и|ами)?|Модель має|$)',
+        re.DOTALL | re.IGNORECASE,
+    ),
+    # "Наповнення матрацу / матраця:" — remove to end
+    re.compile(r'Наповнення матрац[яу][^\n]*:.*$', re.DOTALL | re.IGNORECASE),
+    # "Матеріали та конструкція:" / "Матеріали:" / "Матеріали, що використовуються..."
+    re.compile(r'Матеріали(?:\s+та\s+конструкція|,\s+що\s+використовуються[^:]*)?'
+               r'\s*:.*?(?=Додаткові\s+особливості|$)',
+               re.DOTALL | re.IGNORECASE),
+    # "Додаткові особливості:" — remove to end of that block or next section
+    re.compile(r'Додаткові\s+особливості\s*:.*?(?=\n\n|$)', re.DOTALL | re.IGNORECASE),
+    # "Використовувані / Використані матеріали" — remove to end
+    re.compile(r'Використ(?:овувані|овані|ані) матеріали.*$', re.DOTALL | re.IGNORECASE),
+    # "Переваги покупки" — remove to end
+    re.compile(r'Переваги покупки.*$', re.DOTALL | re.IGNORECASE),
+    # "Купити матрац" — remove to end
+    re.compile(r'Купити матрац.*$', re.DOTALL | re.IGNORECASE),
+    # Shopping hints: "Ціна виробу залежить від розмірів...", "Вибрати найбільш відповідний..."
+    re.compile(r'Ціна виробу залежить[^\.]*\.', re.IGNORECASE),
+    re.compile(r'Вибрати найбільш відповідний[^\.]*\.', re.IGNORECASE),
+    # Manufacturer disclaimer
+    re.compile(r'\*?\s*Виробник залишає за собою право.*$', re.DOTALL | re.IGNORECASE),
+    # Short inline specs lines: "Жорсткість – середня", "Єврокаркас", "Гарантія – X місяців"
+    re.compile(
+        r'\n(?:Жорсткість|Висота|Гарантія|Єврокаркас|Навантаження|Розмір|Матеріал чохла)[^\n]{0,80}',
+        re.IGNORECASE,
+    ),
+]
+
+BRAND_SUBS: list[tuple[re.Pattern, str]] = [
+    # "На сайті Matroluxe/Matro/etc [речення]." — тільки з великої
+    (re.compile(r'На сайті\s+\S*(?:Matrolux[e]?|Matro|Матролюкс|Матро)\S*[^\.]*\.'), ''),
+    # "Зверніть увагу на новинку від ... Sofyno/Matroluxe —"
+    (re.compile(r'Зверніть увагу на новинку від\s+(?:торгової марки\s+)?'
+                r'(?:Sofyno|Matrolux[e]?|Матролюкс)\s*[—–]\s*', re.IGNORECASE), ''),
+    # "від торгової марки Low Cost" / "від Matroluxe"
+    (re.compile(r'від\s+(?:торгової марки\s+)?(?:Low Cost|Matrolux[e]?|Матролюкс)\s*[—–]?\s*',
+                re.IGNORECASE), ''),
+    # "компанії Matroluxe", "фабрики Матролюкс"
+    (re.compile(r'(?:компанії|фабрики|виробника)\s+\S*(?:Matrolux[e]?|Матролюкс)\S*\s*',
+                re.IGNORECASE), ''),
+    # "Торгова марка Sofyno представляє..."
+    (re.compile(r'Торгова марка\s+Sofyno\s+[^—–]+[—–]\s*', re.IGNORECASE), ''),
+    # " ТМ Sofyno" / "торгової марки Sofyno"
+    (re.compile(r'\s+(?:ТМ|торгової марки)\s+Sofyno', re.IGNORECASE), ''),
+    # "на сайті Matro..." всередині речення
+    (re.compile(r'на сайті\s+\S*(?:matro|матро|matrolux)\S*\s*', re.IGNORECASE), ''),
+    # "в інтернет-магазині ..."
+    (re.compile(r'в інтернет-магазині\s+\S+', re.IGNORECASE), ''),
+    # Standalone brand tokens
+    (re.compile(r'\bMatrolux[e]?\b', re.IGNORECASE), ''),
+    (re.compile(r'\bMatro\b', re.IGNORECASE), ''),
+    (re.compile(r'\bSofyno\b', re.IGNORECASE), ''),
+    (re.compile(r'\bLow Cost\b', re.IGNORECASE), ''),
+    (re.compile(r'\bМатролюкс\b'), ''),
+    (re.compile(r'\bматро\b', re.IGNORECASE), ''),
+    (re.compile(r'\bсофіно\b', re.IGNORECASE), ''),
+    # Leftover fragments after brand removal
+    (re.compile(r'\s+від виробника\b', re.IGNORECASE), ''),
+    (re.compile(r',?\s*які представлені\s*', re.IGNORECASE), ''),
+    # "від Це" / "від " at end of sentence (dangling preposition)
+    (re.compile(r'\s+від\s+(?=[А-ЯІЇЄ])', re.IGNORECASE), ' '),
+]
+
+
+def _strip_title_header(text: str) -> str:
+    """Remove leading 'Переваги матраца[-топпера] [назва]' or repeated-name header."""
+    # "Переваги матраца/матраця[-топпера] [name]:" with colon+newline
+    m = re.match(r'^Переваги\s+матрац[яа]?(?:-топпера)?[^\r\n:]{1,120}:\s*\r?\n', text)
+    if m:
+        return text[m.end():]
+    # With just newline
+    m = re.match(r'^Переваги\s+матрац[яа]?(?:-топпера)?[^\r\n]{1,120}\r?\n', text)
+    if m:
+        return text[m.end():]
+    # Concatenated: find lowercase→uppercase Cyrillic boundary within first 150 chars
+    m = re.match(r'^Переваги\s+матрац[яа]?(?:-топпера)?[^\n]{1,150}?[а-яіїєa-z](?=[А-ЯІЇЄ])', text)
+    if m:
+        return text[m.end():]
+    # Fallback: up to first colon
+    m = re.match(r'^Переваги\s+матрац[яа]?(?:-топпера)?[^:]{1,120}:\s*', text)
+    if m:
+        return text[m.end():]
+    # "Матрац [name]\nМатрац [name] від..." — repeated name with newline
+    m = re.match(r'^Матрац\s+\S+(?:/\S+)?\r?\n', text)
+    if m:
+        return text[m.end():]
+    # "Матрац [name]Матрац" — repeated name concatenated
+    m = re.match(r'^(?:Матрац\s+\S+(?:/\S+)?)(?=Матрац\s)', text)
+    if m:
+        return text[m.end():]
+    return text
+
+
+def _clean_whitespace(text: str) -> str:
+    text = text.replace('\r\n', '\n').replace('\r', '\n')
+    text = re.sub(r'[ \t]+', ' ', text)
+    text = re.sub(r' \.', '.', text)
+    text = re.sub(r'\n{3,}', '\n\n', text)
+    return text.strip()
+
+
+def _split_list_items(raw: str) -> list[str]:
+    """Split 'Item1.Item2.' or 'Item1;Item2;' into list items."""
+    items = []
+    for chunk in re.split(r'[\.;]\s*\n?', raw):
+        chunk = chunk.strip()
+        if len(chunk) > 4:
+            items.append(chunk)
+    return items
+
+
+def _clean_name(name: str) -> str:
+    """Remove dimensions and normalize slashes in mattress name."""
+    name = re.sub(r'\s*\(\d+[хx×]\d+(?:[/\d хx×]*)\)\s*$', '', name).strip()
+    name = re.sub(r'\s*/\s*', ' / ', name)
+    return re.sub(r'\s+', ' ', name).strip()
+
+
+def format_mattress_description(raw: str, furniture_name: str) -> str:
+    text = raw.strip()
+
+    # Strip HTML wrapper if it's just a single <p>...</p>
+    if re.match(r'^<p>(.*)</p>$', text, re.DOTALL):
+        text = re.sub(r'^<p>|</p>$', '', text).strip()
+    elif text.count('<') > 2:
+        # Already rich HTML — skip
+        return raw
+
+    # 1. Strip title header
+    text = _strip_title_header(text)
+
+    # 2. Remove unwanted sections
+    for pattern in REMOVE_SECTIONS:
+        text = pattern.sub('', text)
+
+    # 3. Remove brand mentions
+    for pattern, replacement in BRAND_SUBS:
+        text = pattern.sub(replacement, text)
+
+    text = _clean_whitespace(text)
+
+    # Capitalize first letter
+    if text and text[0].islower():
+        text = text[0].upper() + text[1:]
+
+    # 4. Split intro vs advantages list
+    adv_match = ADVANTAGES_HEADER_RE.search(text)
+    if adv_match:
+        intro_raw = text[: adv_match.start()].strip()
+        adv_raw = text[adv_match.end():].strip()
+    else:
+        intro_raw = text
+        adv_raw = ''
+
+    # 5. Build intro HTML — split on blank lines
+    paragraphs = [p.strip() for p in re.split(r'\n\n', intro_raw) if p.strip()]
+    intro_html = ''.join(f'<p>{p}</p>' for p in paragraphs) if paragraphs else ''
+
+    # 6. Build advantages HTML
+    adv_html = ''
+    if adv_raw:
+        items = _split_list_items(adv_raw)
+        if items:
+            items_html = ''.join(f'<li>{item}.</li>' for item in items)
+            adv_html = f'<h3>Переваги:</h3><ul>{items_html}</ul>'
+
+    # 7. Compose final HTML
+    h2 = _clean_name(furniture_name)
+    return f'<h2>{h2}</h2>{intro_html}{adv_html}'
+
+
+class Command(BaseCommand):
+    help = "Переформатовує описи матраців: видаляє бренди/характеристики, додає HTML структуру."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Показати результат без збереження в БД.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=None,
+            help="Обробити лише N матраців (для тесту).",
+        )
+        parser.add_argument(
+            "--verbose",
+            action="store_true",
+            help="Виводити HTML для кожного матраця.",
+        )
+
+    def handle(self, *args, **options):
+        dry_run: bool = options["dry_run"]
+        limit: int | None = options["limit"]
+        verbose: bool = options["verbose"]
+
+        qs = (
+            Furniture.objects.filter(sub_category__category__name="Матраци")
+            .exclude(description="")
+            .select_related("sub_category__category")
+        )
+
+        if limit:
+            qs = qs[:limit]
+
+        updated = skipped = 0
+        for mat in qs.iterator(chunk_size=50):
+            new_desc = format_mattress_description(mat.description, mat.name)
+            if new_desc == mat.description:
+                skipped += 1
+                continue
+
+            updated += 1
+            if verbose:
+                self.stdout.write(f"\n{'='*60}")
+                self.stdout.write(f"ID {mat.id} | {mat.name}")
+                self.stdout.write(new_desc)
+
+            if not dry_run:
+                mat.description = new_desc
+                mat.save(update_fields=["description"])
+
+        tag = "DRY-RUN" if dry_run else "DONE"
+        self.stdout.write(
+            self.style.SUCCESS(f"[{tag}] Оновлено: {updated}, без змін: {skipped}.")
+        )


### PR DESCRIPTION
…cleanup

- reformat_bed_descriptions: HTML formatter for bed descriptions (removes brands, specs, generates h2/p/ul structure)
- reformat_mattress_descriptions: same for mattress category with mattress-specific section patterns
- cleanup_parameters: removes manufacturer params, normalizes dimension units
- deduplicate_parameters: merges duplicate params, normalizes keys via transliteration
- fix list.html: use inline style for bulk bar visibility instead of Tailwind hidden class