### PR TITLE
feat: локальний scrape → JSON → імпорт через custom_admin + очищення …

### DIFF
--- a/custom_admin/templates/custom_admin/kreslalux.html
+++ b/custom_admin/templates/custom_admin/kreslalux.html
@@ -48,6 +48,48 @@
     </div>
 </div>
 
+<!-- JSON file import -->
+<div class="bg-white rounded-xl border border-brown-300 shadow-sm p-6 mb-6">
+    <div class="flex items-center gap-3 mb-4">
+        <div class="w-9 h-9 rounded-lg bg-brown-100 flex items-center justify-center">
+            <i class="fa-solid fa-file-import text-brown-600"></i>
+        </div>
+        <div>
+            <h2 class="text-base font-semibold text-brown-800">Імпорт з файлу (рекомендовано)</h2>
+            <p class="text-xs text-brown-400">Завантажте JSON-файл, зібраний локально</p>
+        </div>
+    </div>
+
+    <div class="mb-4 p-3 bg-beige-50 rounded-lg text-xs text-brown-600 space-y-1">
+        <p><strong>Крок 1.</strong> Запустіть локально на своєму ПК:</p>
+        <code class="block bg-brown-900 text-green-300 rounded px-3 py-2 text-xs mt-1 select-all">
+            python manage.py import_kreslalux_chairs --export-json kreslalux.json
+        </code>
+        <p class="mt-2"><strong>Крок 2.</strong> Завантажте отриманий файл нижче.</p>
+    </div>
+
+    <form method="post" action="{% url 'custom_admin:kreslalux_import_json' %}" enctype="multipart/form-data">
+        {% csrf_token %}
+        <div class="space-y-3 mb-4">
+            <div>
+                <label class="block text-xs font-medium text-brown-600 mb-1">JSON-файл</label>
+                <input type="file" name="json_file" accept=".json" required
+                       class="w-full border border-beige-300 rounded-lg px-3 py-2 text-brown-800 text-sm focus:outline-none focus:ring-2 focus:ring-brown-500 file:mr-3 file:py-1 file:px-3 file:rounded file:border-0 file:text-xs file:bg-brown-100 file:text-brown-700">
+            </div>
+            <div class="flex items-center gap-2">
+                <input type="checkbox" name="dry_run" id="dry_run_json"
+                       class="w-4 h-4 text-brown-600 border-beige-300 rounded">
+                <label for="dry_run_json" class="text-xs text-brown-600">Dry-run (тільки перегляд, без змін)</label>
+            </div>
+        </div>
+        <button type="submit"
+                class="w-full inline-flex items-center justify-center px-4 py-2 bg-brown-700 hover:bg-brown-800 text-white text-sm font-medium rounded-lg transition-colors">
+            <i class="fa-solid fa-upload mr-2"></i>
+            Імпортувати з файлу
+        </button>
+    </form>
+</div>
+
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
 
     <!-- Import -->

--- a/custom_admin/urls.py
+++ b/custom_admin/urls.py
@@ -59,6 +59,7 @@ urlpatterns = [
     path("furniture/bulk-edit/apply/", views.furniture_bulk_edit_apply, name="furniture_bulk_edit_apply"),
     path("kreslalux/", views.kreslalux_page, name="kreslalux"),
     path("kreslalux/import/", views.kreslalux_import, name="kreslalux_import"),
+    path("kreslalux/import-json/", views.kreslalux_import_json, name="kreslalux_import_json"),
     path("kreslalux/update-prices/", views.kreslalux_update_prices, name="kreslalux_update_prices"),
     path("<slug:section_slug>/", views.SectionListView.as_view(), name="list"),
     path("<slug:section_slug>/create/", views.SectionCreateView.as_view(), name="create"),

--- a/custom_admin/views.py
+++ b/custom_admin/views.py
@@ -995,6 +995,63 @@ def kreslalux_import(request):
 
 @login_required
 @require_POST
+def kreslalux_import_json(request):
+    if not request.user.is_staff:
+        raise Http404("Сторінку не знайдено")
+
+    import json
+    from price_parser.kreslalux_scraper import KreslaluxScraper
+
+    uploaded = request.FILES.get("json_file")
+    if not uploaded:
+        messages.error(request, "Файл не завантажено.")
+        return redirect("custom_admin:kreslalux")
+
+    if not uploaded.name.endswith(".json"):
+        messages.error(request, "Файл повинен мати розширення .json")
+        return redirect("custom_admin:kreslalux")
+
+    try:
+        data = json.loads(uploaded.read().decode("utf-8"))
+    except Exception as exc:
+        messages.error(request, f"Помилка читання JSON: {exc}")
+        return redirect("custom_admin:kreslalux")
+
+    if not isinstance(data, list):
+        messages.error(request, "JSON має бути масивом товарів.")
+        return redirect("custom_admin:kreslalux")
+
+    dry_run = bool(request.POST.get("dry_run"))
+
+    try:
+        result = KreslaluxScraper.import_from_data(
+            products=data,
+            dry_run=dry_run,
+        )
+    except Exception as exc:
+        messages.error(request, f"Помилка імпорту: {exc}")
+        return redirect("custom_admin:kreslalux")
+    finally:
+        close_old_connections()
+
+    if result.get("success"):
+        prefix = "[DRY-RUN] " if dry_run else ""
+        messages.success(
+            request,
+            f"{prefix}Файл: {len(data)} записів. "
+            f"Імпорт завершено: створено {result['created']}, "
+            f"оновлено {result['updated']}, пропущено {result['skipped']}.",
+        )
+        if result.get("errors"):
+            messages.warning(request, f"Помилки ({len(result['errors'])}): " + " | ".join(result["errors"][:5]))
+    else:
+        messages.error(request, f"Помилка: {result.get('error', 'Невідома помилка')}")
+
+    return redirect("custom_admin:kreslalux")
+
+
+@login_required
+@require_POST
 def kreslalux_update_prices(request):
     if not request.user.is_staff:
         raise Http404("Сторінку не знайдено")

--- a/furniture/management/commands/import_kreslalux_chairs.py
+++ b/furniture/management/commands/import_kreslalux_chairs.py
@@ -1,4 +1,6 @@
+import json
 from decimal import Decimal
+from pathlib import Path
 
 from django.core.management.base import BaseCommand
 
@@ -6,7 +8,7 @@ from price_parser.kreslalux_scraper import KreslaluxScraper
 
 
 class Command(BaseCommand):
-    help = "Імпорт крісел з kreslalux.ua в підкатегорію 'Ортопедичні крісла'"
+    help = "Імпорт крісел з kreslalux.ua. --export-json: зберегти дані в файл (для запуску локально)."
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -30,21 +32,46 @@ class Command(BaseCommand):
             default="ortopedichni-krisla",
             help="Slug підкатегорії для імпорту",
         )
+        parser.add_argument(
+            "--export-json",
+            metavar="FILE",
+            help="Зберегти зібрані дані у JSON-файл (без імпорту в БД). "
+                 "Потім завантажте файл через custom_admin → Kreslalux → Імпорт з файлу.",
+        )
 
     def handle(self, *args, **options):
         max_price = Decimal(str(options["max_price"]))
         dry_run = options["dry_run"]
         limit = options.get("limit")
         subcategory_slug = options["subcategory"]
+        export_path = options.get("export_json")
 
+        scraper = KreslaluxScraper(max_price=max_price)
+        scraper.set_progress_callback(lambda msg: self.stdout.write(msg))
+
+        # ── Export mode ───────────────────────────────────────────────────────
+        if export_path:
+            self.stdout.write(
+                f"Збираємо дані з kreslalux.ua (ціна ≤ {max_price} грн)"
+                + (f", ліміт {limit}" if limit else "")
+            )
+            products = scraper.export_to_json(limit=limit)
+            out = Path(export_path)
+            out.write_text(json.dumps(products, ensure_ascii=False, indent=2), encoding="utf-8")
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"\nГотово! Зібрано {len(products)} товарів → {out.resolve()}\n"
+                    f"Завантажте цей файл через custom_admin → Kreslalux → «Імпорт з файлу»."
+                )
+            )
+            return
+
+        # ── Direct import mode ────────────────────────────────────────────────
         self.stdout.write(
             f"Старт імпорту kreslalux.ua → підкатегорія '{subcategory_slug}', "
             f"ціна ≤ {max_price} грн"
             + (" [DRY-RUN]" if dry_run else "")
         )
-
-        scraper = KreslaluxScraper(max_price=max_price)
-        scraper.set_progress_callback(lambda msg: self.stdout.write(msg))
 
         result = scraper.run_import(
             dry_run=dry_run,

--- a/price_parser/kreslalux_scraper.py
+++ b/price_parser/kreslalux_scraper.py
@@ -67,6 +67,27 @@ def _parse_price(text: str) -> Optional[Decimal]:
         return None
 
 
+def clean_description(description: str) -> str:
+    """Remove 'Key: value.' fragments from description, keep only narrative sentences."""
+    if not description:
+        return description
+
+    # Split on ". " boundaries and trailing period
+    parts = re.split(r'\.\s+', description.strip().rstrip('.'))
+    # Pattern: sentence that looks like "SomeLabel: some value"
+    # Label = up to ~40 chars without colon, then colon, then content
+    param_re = re.compile(
+        r'^[А-ЯҐЄІЇа-яґєіїA-Za-z0-9][^:]{0,50}:\s*.+$',
+        re.UNICODE,
+    )
+    kept = [s.strip() for s in parts if s.strip() and not param_re.match(s.strip())]
+    result = '. '.join(kept)
+    if result:
+        return result + '.'
+    # Fallback: all sentences looked like params — return original unchanged
+    return description
+
+
 def _generate_slug(name: str) -> str:
     from furniture.models import Furniture
     base = slugify(_transliterate(name)) or "krislo"
@@ -497,6 +518,140 @@ class KreslaluxScraper:
                     gallery.save()
 
             self._log(f"  Додано: {furniture.name} ({furniture.article_code})")
+            stats["created"] += 1
+
+        stats["success"] = True
+        return stats
+
+    # ── JSON export / import ─────────────────────────────────────────────────
+
+    def export_to_json(self, limit: Optional[int] = None) -> List[Dict]:
+        """Scrape catalog + detail pages, return list of serializable product dicts."""
+        candidates = self.collect_candidate_urls(limit=limit)
+        self._log(f"Знайдено кандидатів: {len(candidates)}. Збираємо деталі...")
+
+        products = []
+        for idx, candidate in enumerate(candidates, 1):
+            self._log(f"[{idx}/{len(candidates)}] {candidate['name']}")
+            time.sleep(REQUEST_DELAY)
+            product = self.scrape_product(candidate["url"])
+            if not product:
+                self._log(f"  Пропущено (не завантажилось): {candidate['url']}")
+                continue
+            products.append({
+                "url": product.url,
+                "name": product.name,
+                "article_code": product.article_code,
+                "price": str(product.price),
+                "description": clean_description(product.description),
+                "params": product.params,
+                "image_urls": product.image_urls,
+            })
+            self._log(f"  OK: {product.article_code} — {product.price} грн")
+
+        self._log(f"Експорт завершено: {len(products)} товарів")
+        return products
+
+    @staticmethod
+    def import_from_data(
+        products: List[Dict],
+        dry_run: bool = False,
+        subcategory_slug: str = "ortopedichni-krisla",
+        progress_callback=None,
+    ) -> Dict:
+        """Import products from a list of dicts (JSON-exported data) into the DB."""
+        from sub_categories.models import SubCategory
+        from furniture.models import Furniture, FurnitureImage
+        from params.models import FurnitureParameter, Parameter
+
+        def _log(msg):
+            logger.info(msg)
+            if progress_callback:
+                progress_callback(msg)
+
+        sub_category = SubCategory.objects.filter(slug=subcategory_slug).first()
+        if not sub_category:
+            return {"success": False, "error": f"Підкатегорія '{subcategory_slug}' не знайдена"}
+
+        stats = {"created": 0, "updated": 0, "skipped": 0, "candidates": len(products), "errors": []}
+
+        scraper = KreslaluxScraper.__new__(KreslaluxScraper)
+        scraper.session = None
+        scraper._progress_callback = progress_callback
+
+        for idx, data in enumerate(products, 1):
+            article_code = (data.get("article_code") or "").strip()
+            name = (data.get("name") or "").strip()
+            if not article_code or not name:
+                stats["errors"].append(f"Рядок {idx}: відсутній артикул або назва")
+                stats["skipped"] += 1
+                continue
+
+            try:
+                price = Decimal(str(data.get("price", "0")))
+            except InvalidOperation:
+                price = Decimal("0")
+
+            existing = Furniture.objects.filter(article_code=article_code).first()
+            if existing:
+                if existing.price != price and price > 0:
+                    if not dry_run:
+                        existing.price = price
+                        existing.save(update_fields=["price"])
+                    _log(f"  [{idx}] Оновлено ціну: {name} → {price} грн")
+                    stats["updated"] += 1
+                else:
+                    stats["skipped"] += 1
+                continue
+
+            if dry_run:
+                _log(f"  [{idx}] [DRY-RUN] Створив би: {name} ({article_code}) — {price} грн")
+                stats["created"] += 1
+                continue
+
+            furniture = Furniture.objects.create(
+                name=name,
+                article_code=article_code,
+                slug=_generate_slug(name),
+                sub_category=sub_category,
+                price=price,
+                description=data.get("description") or name,
+                stock_status="in_stock",
+            )
+
+            for param_label, param_value in (data.get("params") or {}).items():
+                if not param_label or not param_value:
+                    continue
+                key = slugify(param_label)[:100] or f"param_{abs(hash(param_label))}"
+                param, _ = Parameter.objects.get_or_create(key=key, defaults={"label": param_label})
+                if not sub_category.allowed_params.filter(pk=param.pk).exists():
+                    sub_category.allowed_params.add(param)
+                FurnitureParameter.objects.update_or_create(
+                    furniture=furniture,
+                    parameter=param,
+                    defaults={"value": param_value},
+                )
+
+            # Download images (needs a session)
+            img_scraper = KreslaluxScraper.__new__(KreslaluxScraper)
+            img_scraper.session = KreslaluxScraper._build_session(img_scraper)
+            for img_idx, img_url in enumerate(data.get("image_urls") or []):
+                cache_path = img_scraper._download_image(img_url)
+                if not cache_path:
+                    continue
+                if img_idx == 0 and not furniture.image:
+                    furniture.image.name = cache_path
+                    furniture.save(update_fields=["image"])
+                else:
+                    gallery = FurnitureImage(
+                        furniture=furniture,
+                        alt_text=f"{furniture.name} — фото {img_idx}",
+                        position=img_idx,
+                    )
+                    gallery.image.name = cache_path
+                    gallery.save()
+
+            _log(f"  [{idx}] Додано: {name} ({article_code})")
             stats["created"] += 1
 
         stats["success"] = True


### PR DESCRIPTION
…опису

- export_to_json() — збирає товари без імпорту в БД
- import_from_data() — імпортує з list[dict] (завантажений JSON)
- clean_description() — прибирає 'Ключ: значення.' фрагменти з опису, залишає лише описовий текст; fallback на оригінал якщо все є параметрами
- management command: --export-json FILE
- custom_admin: новий view + URL kreslalux/import-json/
- kreslalux.html: блок «Імпорт з файлу» з інструкцією