### PR TITLE
feat: сторінка акцій — групування по підкатегоріях з розгортанням

### DIFF
--- a/shop/views.py
+++ b/shop/views.py
@@ -421,11 +421,27 @@ class PromotionsView(TemplateView):
     template_name = "shop/promotions.html"
 
     def get_context_data(self, **kwargs):
-        """Provide full list of active promotional furniture items."""
+        """Provide promotional furniture grouped by subcategory."""
         context = super().get_context_data(**kwargs)
-        context["promotional_items"] = list(
-            fetch_active_promotional_furniture().order_by("-created_at")
-        )
+        all_items = list(fetch_active_promotional_furniture().order_by("-created_at"))
+
+        groups: dict = defaultdict(list)
+        no_subcat: list = []
+        for item in all_items:
+            if item.sub_category:
+                groups[item.sub_category].append(item)
+            else:
+                no_subcat.append(item)
+
+        grouped = [
+            {"subcategory": subcat, "items": items}
+            for subcat, items in sorted(groups.items(), key=lambda x: x[0].name)
+        ]
+        if no_subcat:
+            grouped.append({"subcategory": None, "items": no_subcat})
+
+        context["grouped_items"] = grouped
+        context["has_items"] = bool(all_items)
         context.update(
             {
                 "meta_title": "Акції та знижки на меблі — Montal Home",

--- a/templates/shop/_promo_card.html
+++ b/templates/shop/_promo_card.html
@@ -1,0 +1,61 @@
+{% load cart_filters %}{% load responsive_images %}
+<div class="furniture-card furniture-card--immersive bg-white rounded-2xl overflow-hidden group relative">
+    <a href="{% url 'furniture:furniture_detail' item.slug %}" class="card-full-link">
+        <div class="card-media card-media--immersive">
+            {% if item.best_discount_percentage %}
+                <div class="promotional-badge">
+                    -{{ item.best_discount_percentage }}%
+                </div>
+            {% endif %}
+
+            {% if item.sale_end_date %}
+                <div class="absolute top-4 right-4 z-20">
+                    <div class="bg-black/75 text-white px-3 py-1 rounded-lg text-xs font-mono shadow">
+                        <span class="countdown-timer" data-end="{{ item.sale_end_date_iso }}">--:--:--</span>
+                    </div>
+                </div>
+            {% endif %}
+
+            {% if item.image %}
+                <img
+                    src="{{ item.image|image_variant }}"
+                    srcset="{% responsive_srcset item.image %}"
+                    sizes="{% responsive_sizes %}"
+                    alt="{{ item.name }}"
+                    class="card-media-img"
+                >
+            {% else %}
+                <div class="card-media-placeholder">
+                    <svg class="w-16 h-16 text-beige-300" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd"/>
+                    </svg>
+                </div>
+            {% endif %}
+
+            <div class="card-overlay card-overlay--compact">
+                <div class="card-overlay-heading">
+                    <h2 class="card-overlay-title">{{ item.name }}</h2>
+                    {% if item.sub_category %}
+                        <p class="text-xs text-white/80">{{ item.sub_category.name }}</p>
+                    {% endif %}
+                    <div class="card-overlay-price">
+                        {% if item.best_promotional_price %}
+                            <span class="card-price-current">{{ item.best_promotional_price|floatformat:0 }} грн</span>
+                            {% if item.best_original_price %}
+                                <span class="card-price-old">{{ item.best_original_price|floatformat:0 }} грн</span>
+                            {% endif %}
+                        {% else %}
+                            <span class="card-price-current">{{ item.price|floatformat:0 }} грн</span>
+                        {% endif %}
+                    </div>
+                </div>
+                <span class="card-overlay-cta card-overlay-cta--ghost">
+                    Переглянути
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7"></path>
+                    </svg>
+                </span>
+            </div>
+        </div>
+    </a>
+</div>

--- a/templates/shop/promotions.html
+++ b/templates/shop/promotions.html
@@ -2,109 +2,134 @@
 {% load static %}
 {% load cart_filters %}
 {% load responsive_images %}
+
 {% block content %}
-    <div class="container mx-auto px-4 py-8">
-        <!-- Header Section -->
-        <div class="flex items-center justify-between mb-8">
-            <div class="flex items-center gap-3">
-                <div class="w-10 h-10 bg-red-500 rounded-full flex items-center justify-center">
-                    <svg class="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 20 20">
-                        <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
-                    </svg>
-                </div>
-                <h1 class="text-4xl font-bold text-brown-800">Акційні пропозиції</h1>
+<div class="container mx-auto px-4 py-8">
+
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-10">
+        <div class="flex items-center gap-3">
+            <div class="w-10 h-10 bg-red-500 rounded-full flex items-center justify-center">
+                <svg class="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
+                </svg>
             </div>
-            <div class="hidden md:flex items-center gap-2 text-sm text-brown-600">
-                <span>Обмежена кількість</span>
-                <div class="w-2 h-2 bg-red-500 rounded-full animate-pulse"></div>
-            </div>
+            <h1 class="text-4xl font-bold text-brown-800">Акційні пропозиції</h1>
         </div>
-
-        {% if promotional_items %}
-            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-                {% for item in promotional_items %}
-                    <div class="furniture-card furniture-card--immersive bg-white rounded-2xl overflow-hidden group relative">
-                        <a href="{% url 'furniture:furniture_detail' item.slug %}" class="card-full-link">
-                            <div class="card-media card-media--immersive">
-                                {% if item.best_discount_percentage %}
-                                    <div class="promotional-badge">
-                                        -{{ item.best_discount_percentage }}%
-                                    </div>
-                                {% endif %}
-
-                                {% if item.sale_end_date %}
-                                    <div class="absolute top-4 right-4 z-20">
-                                        <div class="bg-black/75 text-white px-3 py-1 rounded-lg text-xs font-mono shadow">
-                                            <span class="countdown-timer" data-end="{{ item.sale_end_date_iso }}">--:--:--</span>
-                                        </div>
-                                    </div>
-                                {% endif %}
-
-                                {% if item.image %}
-                                    <img
-                                        src="{{ item.image|image_variant }}"
-                                        srcset="{% responsive_srcset item.image %}"
-                                        sizes="{% responsive_sizes %}"
-                                        alt="{{ item.name }}"
-                                        class="card-media-img"
-                                    >
-                                {% else %}
-                                    <div class="card-media-placeholder">
-                                        <svg class="w-16 h-16 text-beige-300" fill="currentColor" viewBox="0 0 20 20">
-                                            <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd"/>
-                                        </svg>
-                                    </div>
-                                {% endif %}
-
-                                <div class="card-overlay card-overlay--compact">
-                                    <div class="card-overlay-heading">
-                                        <h2 class="card-overlay-title">{{ item.name }}</h2>
-                                        {% if item.sub_category %}
-                                            <p class="text-xs text-white/80">
-                                                {{ item.sub_category.category.name }} → {{ item.sub_category.name }}
-                                            </p>
-                                        {% endif %}
-                                        <div class="card-overlay-price">
-                                            {% if item.best_promotional_price %}
-                                                <span class="card-price-current">{{ item.best_promotional_price|floatformat:0 }} грн</span>
-                                                {% if item.best_original_price %}
-                                                    <span class="card-price-old">{{ item.best_original_price|floatformat:0 }} грн</span>
-                                                {% endif %}
-                                            {% else %}
-                                                <span class="card-price-current">{{ item.price|floatformat:0 }} грн</span>
-                                            {% endif %}
-                                        </div>
-                                    </div>
-                                    <span class="card-overlay-cta card-overlay-cta--ghost">
-                                        Переглянути
-                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7"></path>
-                                        </svg>
-                                    </span>
-                                </div>
-                            </div>
-                        </a>
-                    </div>
-                {% endfor %}
-            </div>
-        {% else %}
-            <!-- Empty State -->
-            <div class="text-center py-16">
-                <div class="w-24 h-24 bg-beige-200 rounded-full flex items-center justify-center mx-auto mb-6">
-                    <svg class="w-12 h-12 text-beige-400" fill="currentColor" viewBox="0 0 20 20">
-                        <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
-                    </svg>
-                </div>
-                <h3 class="text-2xl font-bold text-brown-800 mb-2">Наразі немає акційних пропозицій</h3>
-                <p class="text-brown-600 mb-6">Перевірте пізніше або подивіться наші звичайні товари</p>
-                <a href="{% url 'shop:home' %}" class="bg-gradient-to-r from-brown-500 to-brown-600 text-white px-6 py-3 rounded-lg font-semibold hover:from-brown-600 hover:to-brown-700 transition-all duration-300">
-                    Повернутися на головну
-                </a>
-            </div>
-        {% endif %}
+        <div class="hidden md:flex items-center gap-2 text-sm text-brown-600">
+            <span>Обмежена кількість</span>
+            <div class="w-2 h-2 bg-red-500 rounded-full animate-pulse"></div>
+        </div>
     </div>
+
+    {% if has_items %}
+
+        {% for group in grouped_items %}
+        {% with items=group.items subcat=group.subcategory %}
+        <section class="promo-category mb-14" data-section-id="{{ forloop.counter }}">
+
+            <!-- Subcategory heading -->
+            <div class="flex items-center gap-4 mb-6">
+                <h2 class="text-2xl font-bold text-brown-800">
+                    {% if subcat %}{{ subcat.name }}{% else %}Інші{% endif %}
+                </h2>
+                <span class="text-sm text-brown-500 bg-beige-100 px-3 py-1 rounded-full">{{ items|length }} товарів</span>
+                <div class="flex-1 h-px bg-beige-200"></div>
+            </div>
+
+            <!-- Cards wrapper -->
+            <div class="promo-cards-wrap">
+
+                <!-- Visible first row wrapped in relative container for gradient anchor -->
+                <div class="relative">
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                        {% for item in items %}
+                            {% if forloop.counter <= 3 %}
+                                {% include "shop/_promo_card.html" with item=item %}
+                            {% endif %}
+                        {% endfor %}
+                    </div>
+
+                    {% if items|length > 3 %}
+                    <!-- Gradient overlay — z-20 щоб бути поверх карток (z-index: 1/5) -->
+                    <div class="promo-gradient-bar
+                                absolute bottom-0 left-0 right-0 h-32 z-20
+                                bg-gradient-to-t from-white via-white/80 to-transparent
+                                flex items-end justify-center pb-4
+                                pointer-events-none transition-opacity duration-300">
+                        <button
+                            class="promo-show-more pointer-events-auto
+                                   inline-flex items-center gap-2
+                                   bg-brown-600 hover:bg-brown-700 text-white
+                                   px-6 py-2.5 rounded-full text-sm font-semibold
+                                   shadow-lg hover:shadow-xl
+                                   transition-all duration-200 active:scale-95"
+                            aria-expanded="false"
+                        >
+                            <svg class="w-4 h-4 transition-transform duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+                            </svg>
+                            Більше ({{ items|length|add:"-3" }})
+                        </button>
+                    </div>
+                    {% endif %}
+                </div>
+
+                {% if items|length > 3 %}
+                <!-- Extra items (hidden initially) -->
+                <div class="promo-extra-items overflow-hidden"
+                     style="max-height:0; transition: max-height 0.5s ease;">
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 pt-6">
+                        {% for item in items %}
+                            {% if forloop.counter > 3 %}
+                                {% include "shop/_promo_card.html" with item=item %}
+                            {% endif %}
+                        {% endfor %}
+                    </div>
+                </div>
+                {% endif %}
+
+            </div><!-- /promo-cards-wrap -->
+        </section>
+        {% endwith %}
+        {% endfor %}
+
+    {% else %}
+        <!-- Empty state -->
+        <div class="text-center py-16">
+            <div class="w-24 h-24 bg-beige-200 rounded-full flex items-center justify-center mx-auto mb-6">
+                <svg class="w-12 h-12 text-beige-400" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
+                </svg>
+            </div>
+            <h3 class="text-2xl font-bold text-brown-800 mb-2">Наразі немає акційних пропозицій</h3>
+            <p class="text-brown-600 mb-6">Перевірте пізніше або подивіться наші звичайні товари</p>
+            <a href="{% url 'shop:home' %}"
+               class="bg-gradient-to-r from-brown-500 to-brown-600 text-white px-6 py-3 rounded-lg font-semibold hover:from-brown-600 hover:to-brown-700 transition-all duration-300">
+                Повернутися на головну
+            </a>
+        </div>
+    {% endif %}
+
+</div>
 {% endblock %}
 
 {% block extra_body %}
 <script src="{% static 'js/countdown.js' %}"></script>
+<script>
+document.querySelectorAll('.promo-show-more').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+        var wrap = btn.closest('.promo-cards-wrap');
+        var extra = wrap.querySelector('.promo-extra-items');
+        var gradient = wrap.querySelector('.promo-gradient-bar');
+
+        extra.style.maxHeight = extra.scrollHeight + 'px';
+
+        gradient.style.opacity = '0';
+        setTimeout(function() { gradient.style.display = 'none'; }, 300);
+
+        btn.setAttribute('aria-expanded', 'true');
+    });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
- Перегрупування товарів по підкатегорії замість плоского списку
- Перший рядок (3 картки) завжди видимий, решта згорнута
- Градієнт з кнопкою "Більше (N)" поверх першого рядку (z-20)
- Плавне розгортання прихованих карток через max-height transition
- Партіал _promo_card.html для уникнення дублювання HTML