### PR TITLE
feat(sub-categories): сортування та рефакторинг фільтрації

### DIFF
--- a/sub_categories/views.py
+++ b/sub_categories/views.py
@@ -1,19 +1,25 @@
 from django.core.paginator import Paginator
+from django.db.models import Min, Max, Q
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, render
-from django.db.models import Q, Min, Max
 from django.utils.html import strip_tags
 from django.utils.text import Truncator
 from django.views.decorators.cache import cache_page
 
 from furniture.models import Furniture, FurnitureSizeVariant
-from params.models import FurnitureParameter, Parameter
+from params.models import FurnitureParameter
 from sub_categories.models import SubCategory
+
+_SORT_MAP = {
+    "price_asc": "price",
+    "price_desc": "-price",
+    "name_asc": "name",
+    "name_desc": "-name",
+}
 
 
 @cache_page(90)
 def sub_categories_list(request: HttpRequest) -> HttpResponse:
-    # Filter subcategories that have furniture items
     sub_categories = SubCategory.objects.filter(furniture__isnull=False).distinct()
     context = {
         "sub_categories": sub_categories,
@@ -26,160 +32,121 @@ def sub_categories_list(request: HttpRequest) -> HttpResponse:
     return render(request, "sub_categories/sub_categories_list.html", context)
 
 
-@cache_page(120)
 def sub_categories_details(
     request: HttpRequest, sub_categories_slug: str
 ) -> HttpResponse:
     sub_category = get_object_or_404(SubCategory, slug=sub_categories_slug)
-    # Show only base models (group leaders); hide variant items
-    furniture = Furniture.objects.filter(
+
+    # Only group leaders visible in listing (variants accessible from product page)
+    base_qs = Furniture.objects.filter(
         sub_category=sub_category,
         variant_group_leader__isnull=True,
     )
 
-    # Price range filtering
-    min_price = request.GET.get("min_price")
-    max_price = request.GET.get("max_price")
-    
-    # Handle potential list values
-    if isinstance(min_price, list):
-        min_price = min_price[0] if min_price else None
-    if isinstance(max_price, list):
-        max_price = max_price[0] if max_price else None
-    
-    if min_price:
-        try:
-            min_price = float(min_price)
-            furniture = furniture.filter(price__gte=min_price)
-        except (ValueError, TypeError):
-            pass
-    
-    if max_price:
-        try:
-            max_price = float(max_price)
-            furniture = furniture.filter(price__lte=max_price)
-        except (ValueError, TypeError):
-            pass
-
-    # Stock status filtering
-    stock_status_list = request.GET.getlist("stock_status")
-    if stock_status_list:
-        furniture = furniture.filter(stock_status__in=stock_status_list)
-
-    # Promotional items filtering
-    promotional_only = request.GET.get("promotional_only")
-    if isinstance(promotional_only, list):
-        promotional_only = promotional_only[0] if promotional_only else None
-    if promotional_only:
-        furniture = furniture.filter(is_promotional=True, promotional_price__isnull=False)
-
-    # Parameter filtering
-    params_in_use = Parameter.objects.filter(
-        Q(furniture_parameters__furniture__sub_category=sub_category)
-        | Q(size_variants__furniture__sub_category=sub_category)
-    ).distinct()
-
-    parameter_filters = []
-    for param in params_in_use:
-        param_key = f"param_{param.key}"
-        if param_key in request.GET and request.GET[param_key]:
-            param_value = request.GET[param_key]
-            # Handle potential list values
-            if isinstance(param_value, list):
-                param_value = param_value[0] if param_value else None
-            if param_value:
-                parameter_filters.append((param_key, param_value))
-
-    # Apply parameter filters
-    for param_key, value in parameter_filters:
-        key = param_key.replace("param_", "")
-        furniture = furniture.filter(
-            Q(parameters__parameter__key=key, parameters__value=value)
-            | Q(
-                size_variants__parameter__key=key,
-                size_variants__parameter_value=value,
-            )
-        )
-
-    if parameter_filters:
-        furniture = furniture.distinct()
-
-    # Sorting
-    sort = request.GET.get("sort", "")
-    if isinstance(sort, list):
-        sort = sort[0] if sort else ""
-    
-    if sort == "price_asc":
-        furniture = furniture.order_by("price")
-    elif sort == "price_desc":
-        furniture = furniture.order_by("-price")
-    elif sort == "name_asc":
-        furniture = furniture.order_by("name")
-    elif sort == "name_desc":
-        furniture = furniture.order_by("-name")
-    else:
-        # Default sorting: promotional items first, then by name
-        furniture = furniture.order_by("-is_promotional", "name")
-
-    # Pagination
-    paginator = Paginator(furniture, 12)  # 12 items per page
-    
-    # Get page number, handling potential list values
-    page_number = request.GET.get("page")
-    if isinstance(page_number, list):
-        page_number = page_number[0] if page_number else None
-    
-    page_obj = paginator.get_page(page_number)
-
-    # Prepare filter options
-    filter_options = {}
-    for param in params_in_use:
-        base_values = set(
-            FurnitureParameter.objects.filter(
-                furniture__sub_category=sub_category,
-                parameter__key=param.key,
-            )
-            .exclude(value__isnull=True)
-            .exclude(value__exact="")
-            .values_list("value", flat=True)
-            .distinct()
-        )
-
-        variant_values = set(
-            FurnitureSizeVariant.objects.filter(
-                furniture__sub_category=sub_category,
-                parameter__key=param.key,
-            )
-            .exclude(parameter_value__isnull=True)
-            .exclude(parameter_value__exact="")
-            .values_list("parameter_value", flat=True)
-            .distinct()
-        )
-
-        combined_values = sorted((base_values | variant_values))
-
-        filter_options[param.key] = {
-            "label": param.label,
-            "values": combined_values,
-        }
-
-    # Get price range for the category
-    price_range = furniture.aggregate(
-        min_price=Min('price'),
-        max_price=Max('price')
+    # --- Build filter options in 2 queries (not N×2) ---
+    fp_rows = (
+        FurnitureParameter.objects
+        .filter(furniture__sub_category=sub_category)
+        .exclude(value="").exclude(value__isnull=True)
+        .values("parameter__key", "parameter__label", "value")
+        .distinct()
+    )
+    sv_rows = (
+        FurnitureSizeVariant.objects
+        .filter(furniture__sub_category=sub_category)
+        .exclude(parameter_value="").exclude(parameter_value__isnull=True)
+        .exclude(parameter__isnull=True)
+        .values("parameter__key", "parameter__label", "parameter_value")
+        .distinct()
     )
 
+    raw_options: dict[str, dict] = {}
+    for row in fp_rows:
+        key = row["parameter__key"]
+        if key not in raw_options:
+            raw_options[key] = {"label": row["parameter__label"], "values": set()}
+        raw_options[key]["values"].add(row["value"])
+    for row in sv_rows:
+        key = row["parameter__key"]
+        if key not in raw_options:
+            raw_options[key] = {"label": row["parameter__label"], "values": set()}
+        raw_options[key]["values"].add(row["parameter_value"])
+
+    # Only expose params with 2+ distinct values (single-value params useless as filter)
+    filter_options = {
+        k: {"label": v["label"], "values": sorted(v["values"])}
+        for k, v in raw_options.items()
+        if len(v["values"]) >= 2
+    }
+
+    # --- Read active filters ---
+    min_price_raw = request.GET.get("min_price", "").strip()
+    max_price_raw = request.GET.get("max_price", "").strip()
+    stock_status_list = request.GET.getlist("stock_status")
+    promotional_only = bool(request.GET.get("promotional_only", "").strip())
+    sort = request.GET.get("sort", "").strip()
+    if sort not in _SORT_MAP:
+        sort = ""
+
+    active_param_filters: dict[str, str] = {}
+    for key in filter_options:
+        val = request.GET.get(f"param_{key}", "").strip()
+        if val:
+            active_param_filters[key] = val
+
+    # --- Price range from full unfiltered queryset ---
+    price_range = base_qs.aggregate(min_price=Min("price"), max_price=Max("price"))
+
+    # --- Apply filters ---
+    qs = base_qs
+
+    if min_price_raw:
+        try:
+            qs = qs.filter(price__gte=float(min_price_raw))
+        except ValueError:
+            min_price_raw = ""
+
+    if max_price_raw:
+        try:
+            qs = qs.filter(price__lte=float(max_price_raw))
+        except ValueError:
+            max_price_raw = ""
+
+    if stock_status_list:
+        qs = qs.filter(stock_status__in=stock_status_list)
+
+    if promotional_only:
+        qs = qs.filter(is_promotional=True, promotional_price__isnull=False)
+
+    for key, value in active_param_filters.items():
+        qs = qs.filter(
+            Q(parameters__parameter__key=key, parameters__value=value)
+            | Q(size_variants__parameter__key=key, size_variants__parameter_value=value)
+        )
+
+    if active_param_filters:
+        qs = qs.distinct()
+
+    # --- Sort ---
+    order = _SORT_MAP.get(sort)
+    qs = qs.order_by(order) if order else qs.order_by("-is_promotional", "name")
+
+    # --- Paginate ---
+    paginator = Paginator(qs, 12)
+    page_obj = paginator.get_page(request.GET.get("page"))
+
     def summarize(text: str, length: int = 160) -> str:
-        clean_text = strip_tags(text or "")
-        return Truncator(clean_text).chars(length, truncate="…")
+        return Truncator(strip_tags(text or "")).chars(length, truncate="…")
 
     context = {
         "sub_category": sub_category,
         "page_obj": page_obj,
         "filter_options": filter_options,
-        "current_filters": parameter_filters,
+        "active_param_filters": active_param_filters,
         "current_sort": sort,
         "price_range": price_range,
+        "min_price_raw": min_price_raw,
+        "max_price_raw": max_price_raw,
         "meta_title": f"{sub_category.name} — меблі Montal Home",
         "meta_description": summarize(
             f"Дивіться меблі у підкатегорії {sub_category.name} від Montal Home. "

--- a/templates/sub_categories/sub_category_detail.html
+++ b/templates/sub_categories/sub_category_detail.html
@@ -31,9 +31,10 @@
                                 <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"/>
                             </svg>
                         </button>
-                        <button id="clearAllFilters" class="text-sm text-red-500 hover:text-red-700 transition-colors">
+                        <a href="{% url 'sub_categories:sub_categories_details' sub_category.slug %}"
+                           class="text-sm text-red-500 hover:text-red-700 transition-colors">
                             Очистити все
-                        </button>
+                        </a>
                     </div>
 
                     <div id="filtersContent" class="filters-content">
@@ -49,11 +50,11 @@
                             <div class="filter-content">
                                 <div class="space-y-1">
                                     <div class="flex gap-2">
-                                        <input type="number" name="min_price" placeholder="Від" 
-                                               value="{{ request.GET.min_price|default:'' }}"
+                                        <input type="number" name="min_price" placeholder="Від {{ price_range.min_price|floatformat:0 }}"
+                                               value="{{ min_price_raw }}"
                                                class="w-full px-3 py-2 border border-beige-300 rounded-lg focus:ring-2 focus:ring-brown-500 focus:border-transparent">
-                                        <input type="number" name="max_price" placeholder="До" 
-                                               value="{{ request.GET.max_price|default:'' }}"
+                                        <input type="number" name="max_price" placeholder="До {{ price_range.max_price|floatformat:0 }}"
+                                               value="{{ max_price_raw }}"
                                                class="w-full px-3 py-2 border border-beige-300 rounded-lg focus:ring-2 focus:ring-brown-500 focus:border-transparent">
                                     </div>
                                     <div class="text-xs text-brown-600">
@@ -110,52 +111,9 @@
                             </div>
                         </div>
 
-                        <!-- Sorting -->
-                        <div class="filter-section mb-3">
-                            <div class="filter-header" onclick="toggleFilterSection(this)">
-                                <h3 class="text-lg font-semibold text-brown-700">Сортування</h3>
-                                <svg class="w-5 h-5 text-brown-500 transform transition-transform" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"/>
-                                </svg>
-                            </div>
-                            <div class="filter-content">
-                                <div class="space-y-1">
-                                    <label class="flex items-center gap-2 cursor-pointer">
-                                        <input type="radio" name="sort" value="" 
-                                               {% if not current_sort %}checked{% endif %}
-                                               class="w-4 h-4 text-brown-600 border-beige-300 focus:ring-brown-500">
-                                        <span class="text-brown-700">За замовчуванням</span>
-                                    </label>
-                                    <label class="flex items-center gap-2 cursor-pointer">
-                                        <input type="radio" name="sort" value="price_asc" 
-                                               {% if current_sort == 'price_asc' %}checked{% endif %}
-                                               class="w-4 h-4 text-brown-600 border-beige-300 focus:ring-brown-500">
-                                        <span class="text-brown-700">Від дешевого до дорогого</span>
-                                    </label>
-                                    <label class="flex items-center gap-2 cursor-pointer">
-                                        <input type="radio" name="sort" value="price_desc" 
-                                               {% if current_sort == 'price_desc' %}checked{% endif %}
-                                               class="w-4 h-4 text-brown-600 border-beige-300 focus:ring-brown-500">
-                                        <span class="text-brown-700">Від дорогого до дешевого</span>
-                                    </label>
-                                    <label class="flex items-center gap-2 cursor-pointer">
-                                        <input type="radio" name="sort" value="name_asc" 
-                                               {% if current_sort == 'name_asc' %}checked{% endif %}
-                                               class="w-4 h-4 text-brown-600 border-beige-300 focus:ring-brown-500">
-                                        <span class="text-brown-700">За назвою А-Я</span>
-                                    </label>
-                                    <label class="flex items-center gap-2 cursor-pointer">
-                                        <input type="radio" name="sort" value="name_desc" 
-                                               {% if current_sort == 'name_desc' %}checked{% endif %}
-                                               class="w-4 h-4 text-brown-600 border-beige-300 focus:ring-brown-500">
-                                        <span class="text-brown-700">За назвою Я-А</span>
-                                    </label>
-                                </div>
-                            </div>
-                        </div>
-
                         <!-- Parameter Filters -->
                         {% for key, param in filter_options.items %}
+                        {% with active_val=active_param_filters|get_item:key %}
                         <div class="filter-section mb-3">
                             <div class="filter-header" onclick="toggleFilterSection(this)">
                                 <h3 class="text-lg font-semibold text-brown-700">{{ param.label }}</h3>
@@ -166,15 +124,15 @@
                             <div class="filter-content">
                                 <div class="space-y-0.5 max-h-48 overflow-y-auto">
                                     <label class="flex items-center gap-2 cursor-pointer">
-                                        <input type="radio" name="param_{{ key }}" value="" 
-                                               {% if not request.GET|get_item:'param_'|add:key %}checked{% endif %}
+                                        <input type="radio" name="param_{{ key }}" value=""
+                                               {% if not active_val %}checked{% endif %}
                                                class="w-4 h-4 text-brown-600 border-beige-300 focus:ring-brown-500">
                                         <span class="text-brown-700">Усі</span>
                                     </label>
                                     {% for value in param.values %}
                                     <label class="flex items-center gap-2 cursor-pointer">
                                         <input type="radio" name="param_{{ key }}" value="{{ value }}"
-                                               {% if request.GET|get_item:'param_'|add:key == value %}checked{% endif %}
+                                               {% if active_val == value %}checked{% endif %}
                                                class="w-4 h-4 text-brown-600 border-beige-300 focus:ring-brown-500">
                                         <span class="text-brown-700">{{ value }}</span>
                                     </label>
@@ -182,6 +140,7 @@
                                 </div>
                             </div>
                         </div>
+                        {% endwith %}
                         {% endfor %}
 
                         <!-- Filter Actions -->
@@ -202,18 +161,19 @@
             <!-- Products Grid -->
             <div class="lg:w-3/4">
                 <!-- Active Filters Display -->
-                {% if current_filters or request.GET.min_price or request.GET.max_price or request.GET|has_stock_status or request.GET.promotional_only %}
+                {% if active_param_filters or min_price_raw or max_price_raw or request.GET|has_stock_status or request.GET.promotional_only %}
                 <div class="bg-white rounded-lg shadow-md p-4 mb-6">
                     <div class="flex items-center justify-between">
                         <h3 class="text-lg font-semibold text-brown-700">Активні фільтри:</h3>
-                        <button onclick="clearAllFilters()" class="text-sm text-red-500 hover:text-red-700 transition-colors">
+                        <a href="{% url 'sub_categories:sub_categories_details' sub_category.slug %}"
+                           class="text-sm text-red-500 hover:text-red-700 transition-colors">
                             Очистити все
-                        </button>
+                        </a>
                     </div>
                     <div class="flex flex-wrap gap-2 mt-3">
-                        {% if request.GET.min_price or request.GET.max_price %}
+                        {% if min_price_raw or max_price_raw %}
                         <span class="bg-brown-100 text-brown-700 px-3 py-1 rounded-full text-sm">
-                            Ціна: {{ request.GET.min_price|default:'0' }} - {{ request.GET.max_price|default:'∞' }} грн
+                            Ціна: {{ min_price_raw|default:'0' }} – {{ max_price_raw|default:'∞' }} грн
                         </span>
                         {% endif %}
                         {% for status in request.GET|getlist:'stock_status' %}
@@ -226,14 +186,34 @@
                             Тільки акційні
                         </span>
                         {% endif %}
-                        {% for filter_key, filter_value in current_filters %}
+                        {% for key, value in active_param_filters.items %}
+                        {% with param_meta=filter_options|get_item:key %}
                         <span class="bg-blue-100 text-blue-700 px-3 py-1 rounded-full text-sm">
-                            {{ filter_key|replace:'param_:'|title }}: {{ filter_value }}
+                            {{ param_meta.label }}: {{ value }}
                         </span>
+                        {% endwith %}
                         {% endfor %}
                     </div>
                 </div>
                 {% endif %}
+
+                <!-- Sort Bar -->
+                <div class="flex items-center justify-between bg-white rounded-xl shadow-sm px-4 py-3 mb-5">
+                    <span class="text-sm text-brown-600">
+                        Знайдено: <strong>{{ page_obj.paginator.count }}</strong> товарів
+                    </span>
+                    <div class="flex items-center gap-2">
+                        <label for="sortSelect" class="text-sm text-brown-600 whitespace-nowrap">Сортувати:</label>
+                        <select id="sortSelect" onchange="applySort(this.value)"
+                                class="text-sm border border-beige-300 rounded-lg px-3 py-1.5 text-brown-800 focus:ring-2 focus:ring-brown-500 focus:border-transparent bg-white cursor-pointer">
+                            <option value="" {% if not current_sort %}selected{% endif %}>За замовчуванням</option>
+                            <option value="price_asc" {% if current_sort == 'price_asc' %}selected{% endif %}>Від дешевого до дорогого</option>
+                            <option value="price_desc" {% if current_sort == 'price_desc' %}selected{% endif %}>Від дорогого до дешевого</option>
+                            <option value="name_asc" {% if current_sort == 'name_asc' %}selected{% endif %}>За назвою А-Я</option>
+                            <option value="name_desc" {% if current_sort == 'name_desc' %}selected{% endif %}>За назвою Я-А</option>
+                        </select>
+                    </div>
+                </div>
 
                 <!-- Products Grid -->
                 {% if page_obj %}
@@ -340,4 +320,19 @@
             </div>
         </div>
     </div>
+{% endblock %}
+
+{% block extra_body %}
+<script>
+function applySort(sortValue) {
+    const params = new URLSearchParams(window.location.search);
+    if (sortValue) {
+        params.set('sort', sortValue);
+    } else {
+        params.delete('sort');
+    }
+    params.delete('page');
+    window.location.href = window.location.pathname + '?' + params.toString();
+}
+</script>
 {% endblock %}


### PR DESCRIPTION
- Sort-бар над гридом товарів: dropdown із миттєвим застосуванням
- Видалено SubCategory.allowed_params (таблиця вже була видалена з БД); міграція 0003 через SeparateDatabaseAndState — лише оновлення стану
- Фільтрація параметрів: динамічно з FurnitureParameter/FurnitureSizeVariant замість allowed_params (2 запити замість N×2)
- price_range рахується на повному незафільтрованому queryset
- Виправлено checked-стан radio-кнопок параметрів у шаблоні
- active_param_filters як dict {key: value} — замість списку кортежів
- Прибрано мертвий код isinstance(x, list) та @cache_page з detail-view
- Видалено allowed_params з усіх імпортерів, скраперів, форм та адміну