### PR TITLE
feat(evrodim): --update-params для оновлення характеристик без реімпорту

### DIFF
--- a/custom_admin/templates/custom_admin/evrodim.html
+++ b/custom_admin/templates/custom_admin/evrodim.html
@@ -92,19 +92,32 @@
             Може займати ~5–10 хв. Нові товари не створюються.
         </p>
 
-        <form method="post" action="{% url 'custom_admin:evrodim_update_prices' %}"
-              onsubmit="this.querySelector('button').disabled=true; this.querySelector('button').textContent='Оновлення...'">
-            {% csrf_token %}
-            <button type="submit"
-                    class="inline-flex items-center gap-2 px-4 py-2 bg-brown-700 text-white text-sm rounded-md hover:bg-brown-800 transition-colors">
-                <i class="fa-solid fa-rotate"></i>
-                Оновити ціни зараз
-            </button>
-        </form>
+        <div class="flex flex-wrap gap-3">
+            <form method="post" action="{% url 'custom_admin:evrodim_update_prices' %}"
+                  onsubmit="this.querySelector('button').disabled=true; this.querySelector('button').textContent='Оновлення...'">
+                {% csrf_token %}
+                <button type="submit"
+                        class="inline-flex items-center gap-2 px-4 py-2 bg-brown-700 text-white text-sm rounded-md hover:bg-brown-800 transition-colors">
+                    <i class="fa-solid fa-rotate"></i>
+                    Оновити ціни
+                </button>
+            </form>
+            <form method="post" action="{% url 'custom_admin:evrodim_update_params' %}"
+                  onsubmit="this.querySelector('button').disabled=true; this.querySelector('button').textContent='Оновлення...'">
+                {% csrf_token %}
+                <button type="submit"
+                        class="inline-flex items-center gap-2 px-4 py-2 bg-brown-600 text-white text-sm rounded-md hover:bg-brown-700 transition-colors">
+                    <i class="fa-solid fa-list"></i>
+                    Оновити характеристики
+                </button>
+            </form>
+        </div>
 
         <div class="mt-4 space-y-2">
             <p class="text-xs font-medium text-brown-600 mt-3">Або локально:</p>
             <code class="block bg-brown-900 text-green-300 rounded px-3 py-2 text-xs select-all">python manage.py import_evrodim_tables --update-prices</code>
+            <p class="text-xs font-medium text-brown-600 mt-3">Оновити характеристики (Розміри тощо):</p>
+            <code class="block bg-brown-900 text-green-300 rounded px-3 py-2 text-xs select-all">python manage.py import_evrodim_tables --update-params</code>
             <p class="text-xs font-medium text-brown-600 mt-3">На продакшн БД:</p>
             <code class="block bg-brown-900 text-green-300 rounded px-3 py-2 text-xs select-all">python manage.py import_evrodim_tables --database-url postgres://...</code>
         </div>

--- a/custom_admin/urls.py
+++ b/custom_admin/urls.py
@@ -62,6 +62,7 @@ urlpatterns = [
     path("palette-colors/bulk-edit/", views.palette_colors_bulk_edit, name="palette_colors_bulk_edit"),
     path("evrodim/", views.evrodim_page, name="evrodim"),
     path("evrodim/update-prices/", views.evrodim_update_prices, name="evrodim_update_prices"),
+    path("evrodim/update-params/", views.evrodim_update_params, name="evrodim_update_params"),
     path("kreslalux/", views.kreslalux_page, name="kreslalux"),
     path("eurosof-prices/", views.eurosof_price_config, name="eurosof_price_config"),
     path("<slug:section_slug>/", views.SectionListView.as_view(), name="list"),

--- a/custom_admin/views.py
+++ b/custom_admin/views.py
@@ -1073,6 +1073,35 @@ def evrodim_update_prices(request):
     return redirect("custom_admin:evrodim")
 
 
+@login_required
+def evrodim_update_params(request):
+    if not request.user.is_staff:
+        raise Http404("Сторінку не знайдено")
+
+    from price_parser.evrodim_scraper import EvrodimScraper
+
+    logs: list[str] = []
+    scraper = EvrodimScraper()
+    scraper.set_progress_callback(logs.append)
+
+    try:
+        result = scraper.update_params(subcategory_slug="stoly-evrodim")
+    except Exception as exc:
+        messages.error(request, f"Помилка під час оновлення характеристик: {exc}")
+        return redirect("custom_admin:evrodim")
+
+    if result.get("success"):
+        messages.success(
+            request,
+            f"Характеристики оновлено: перевірено {result['checked']}, "
+            f"оновлено {result['updated']}, не знайдено {result['not_found']}",
+        )
+    else:
+        messages.error(request, f"Помилка: {result.get('error')}")
+
+    return redirect("custom_admin:evrodim")
+
+
 # ── Kreslalux scraper views ───────────────────────────────────────────────────
 
 @login_required

--- a/furniture/management/commands/import_evrodim_tables.py
+++ b/furniture/management/commands/import_evrodim_tables.py
@@ -29,6 +29,11 @@ class Command(BaseCommand):
             help="Тільки оновити ціни існуючих товарів",
         )
         parser.add_argument(
+            "--update-params",
+            action="store_true",
+            help="Тільки оновити характеристики (Розміри тощо) існуючих товарів",
+        )
+        parser.add_argument(
             "--database-url",
             metavar="URL",
             help="URL продакшн БД (postgres://user:pass@host/db)",
@@ -48,11 +53,14 @@ class Command(BaseCommand):
         dry_run = options["dry_run"]
         limit = options.get("limit")
         update_only = options["update_prices"]
+        update_params = options["update_params"]
 
         scraper = EvrodimScraper()
         scraper.set_progress_callback(lambda msg: self.stdout.write(msg))
 
-        if update_only:
+        if update_params:
+            result = scraper.update_params(subcategory_slug)
+        elif update_only:
             result = scraper.update_prices(subcategory_slug)
         else:
             self.stdout.write(
@@ -71,7 +79,14 @@ class Command(BaseCommand):
             self.stdout.write(self.style.ERROR(f"Помилка: {result.get('error')}"))
             return
 
-        if update_only:
+        if update_params:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Характеристики оновлено: перевірено={result['checked']}, "
+                    f"оновлено={result['updated']}, не знайдено={result['not_found']}"
+                )
+            )
+        elif update_only:
             self.stdout.write(
                 self.style.SUCCESS(
                     f"Ціни оновлено: перевірено={result['checked']}, "

--- a/price_parser/evrodim_scraper.py
+++ b/price_parser/evrodim_scraper.py
@@ -665,3 +665,59 @@ class EvrodimScraper:
 
         stats["success"] = True
         return stats
+
+    # ── Params update ─────────────────────────────────────────────────────────
+
+    def update_params(self, subcategory_slug: str) -> Dict:
+        """Оновлює характеристики (включно з Розмірами) для вже імпортованих товарів."""
+        from furniture.models import Furniture
+        from params.models import FurnitureParameter, Parameter
+
+        self._log("Оновлення характеристик Evrodim...")
+
+        furniture_map: Dict[str, int] = {
+            f.article_code: f.id
+            for f in Furniture.objects.filter(sub_category__slug=subcategory_slug)
+            .only("id", "article_code")
+            if f.article_code
+        }
+
+        if not furniture_map:
+            return {"success": False, "error": "Немає товарів — спочатку запустіть import"}
+
+        all_urls = self.collect_product_urls()
+        stats = {"checked": 0, "updated": 0, "not_found": 0}
+
+        for idx, url in enumerate(all_urls, 1):
+            self._log(f"[{idx}/{len(all_urls)}] {url}")
+            time.sleep(REQUEST_DELAY)
+
+            product = self.scrape_product(url)
+            if not product:
+                continue
+
+            furniture_id = furniture_map.get(product.article_code)
+            if not furniture_id:
+                stats["not_found"] += 1
+                continue
+
+            stats["checked"] += 1
+            if not product.params:
+                continue
+
+            for param_label, param_value in product.params.items():
+                if not param_label or not param_value:
+                    continue
+                key = slugify(_transliterate(param_label))[:100] or f"param_{abs(hash(param_label))}"
+                param, _ = Parameter.objects.get_or_create(key=key, defaults={"label": param_label})
+                FurnitureParameter.objects.update_or_create(
+                    furniture_id=furniture_id,
+                    parameter=param,
+                    defaults={"value": param_value},
+                )
+
+            self._log(f"  {product.article_code}: {len(product.params)} параметрів")
+            stats["updated"] += 1
+
+        stats["success"] = True
+        return stats


### PR DESCRIPTION
Додає можливість дозаписати Розміри (Довжина/Ширина тощо) для вже імпортованих товарів без повного реімпорту: обходить каталог, знаходить товари за article_code і виконує update_or_create для параметрів.

- EvrodimScraper.update_params() — новий метод
- management command: --update-params прапор
- custom_admin: кнопка «Оновити характеристики» + URL evrodim/update-params/