### PR TITLE
fix(cache): виправлення Redis-несумісних патернів і зайвих SELECT 1

### DIFF
--- a/shop/apps.py
+++ b/shop/apps.py
@@ -1,7 +1,4 @@
 from django.apps import AppConfig
-import os
-import shutil
-import glob
 
 
 class ShopConfig(AppConfig):
@@ -9,62 +6,4 @@ class ShopConfig(AppConfig):
     name = "shop"
 
     def ready(self):
-        """Clear cache when Django starts"""
-        import django
-        if django.setup:
-            # Only run in development
-            from django.conf import settings
-            if settings.DEBUG:
-                self.clear_cache_on_startup()
-
-    def clear_cache_on_startup(self):
-        """Clear cache files on server startup"""
-        from django.conf import settings
-        import os
-        
-        print("🧹 Clearing cache on startup...")
-        
-        # Clear __pycache__ directories
-        base_dir = settings.BASE_DIR
-        pycache_count = 0
-        pyc_count = 0
-        
-        # Find and remove __pycache__ directories
-        for root, dirs, files in os.walk(base_dir):
-            for dir_name in dirs:
-                if dir_name == '__pycache__':
-                    pycache_path = os.path.join(root, dir_name)
-                    try:
-                        shutil.rmtree(pycache_path)
-                        pycache_count += 1
-                    except OSError:
-                        pass
-        
-        # Remove .pyc files
-        for root, dirs, files in os.walk(base_dir):
-            for file in files:
-                if file.endswith('.pyc'):
-                    pyc_path = os.path.join(root, file)
-                    try:
-                        os.remove(pyc_path)
-                        pyc_count += 1
-                    except OSError:
-                        pass
-        
-        # Touch static files to update timestamps
-        static_dirs = getattr(settings, 'STATICFILES_DIRS', [])
-        touched_count = 0
-        
-        for static_dir in static_dirs:
-            if os.path.exists(static_dir):
-                for root, dirs, files in os.walk(static_dir):
-                    for file in files:
-                        if file.endswith(('.css', '.js', '.png', '.jpg', '.jpeg', '.gif', '.svg', '.ico')):
-                            file_path = os.path.join(root, file)
-                            try:
-                                os.utime(file_path, None)
-                                touched_count += 1
-                            except OSError:
-                                pass
-        
-        print(f"✅ Cache cleared: {pycache_count} __pycache__ dirs, {pyc_count} .pyc files, {touched_count} static files touched")
+        import shop.signals  # noqa: F401

--- a/shop/management/commands/clear_cache.py
+++ b/shop/management/commands/clear_cache.py
@@ -1,14 +1,22 @@
+from django.core.cache import cache
 from django.core.management.base import BaseCommand
 import os
 import shutil
 
 class Command(BaseCommand):
-    help = 'Clear all cache files (__pycache__, .pyc, static files)'
+    help = 'Clear Django cache (Redis/LocMem) and bytecode files'
 
     def handle(self, *args, **options):
         from django.conf import settings
-        
-        self.stdout.write('🧹 Clearing cache...')
+
+        self.stdout.write('Clearing cache...')
+
+        # Clear Django cache (Redis or LocMem)
+        try:
+            cache.clear()
+            self.stdout.write(self.style.SUCCESS('Django cache cleared'))
+        except Exception as e:
+            self.stdout.write(self.style.WARNING(f'Django cache clear failed: {e}'))
         
         # Clear __pycache__ directories
         base_dir = settings.BASE_DIR

--- a/shop/signals.py
+++ b/shop/signals.py
@@ -1,0 +1,40 @@
+from django.core.cache import cache
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from categories.models import Category
+from furniture.models import Furniture
+from shop.models import SeasonalSettings
+from sub_categories.models import SubCategory
+
+
+def _delete_pattern(pattern: str) -> None:
+    """Delete cache keys matching pattern. Falls back silently for LocMem."""
+    try:
+        cache.delete_pattern(pattern)
+    except AttributeError:
+        pass
+
+
+@receiver(post_save, sender=Category)
+def invalidate_category_cache(sender, **kwargs):
+    cache.delete("categories:with_furniture")
+    _delete_pattern("breadcrumbs::*")
+
+
+@receiver(post_save, sender=SubCategory)
+def invalidate_subcategory_cache(sender, **kwargs):
+    _delete_pattern("breadcrumbs::*")
+
+
+@receiver(post_save, sender=Furniture)
+def invalidate_furniture_cache(sender, **kwargs):
+    cache.delete("promotional_furniture_ids")
+    cache.delete("categories:with_furniture")
+    _delete_pattern("breadcrumbs::*")
+    _delete_pattern("search_suggestions::*")
+
+
+@receiver(post_save, sender=SeasonalSettings)
+def invalidate_seasonal_cache(sender, **kwargs):
+    cache.delete("seasonal_pack_settings")

--- a/store/admin_utils.py
+++ b/store/admin_utils.py
@@ -177,7 +177,11 @@ def admin_retry_failed_operations_view(request):
             if operation_type == 'clear_drafts':
                 # Clear all saved drafts
                 from django.core.cache import cache
-                cache.delete_many([key for key in cache._cache.keys() if key.startswith('form_draft_')])
+                try:
+                    cache.delete_pattern("*form_draft_*")
+                except AttributeError:
+                    raw = getattr(cache, '_cache', {})
+                    cache.delete_many([k for k in list(raw.keys()) if "form_draft_" in k])
                 messages.success(request, "All saved drafts have been cleared.")
             elif operation_type == 'retry_connection':
                 # Test database connection

--- a/store/connection_utils.py
+++ b/store/connection_utils.py
@@ -94,15 +94,33 @@ def retry_with_backoff(
     return decorator
 
 
+_DB_HEALTH_CACHE_KEY = "_db_health_status"
+_DB_HEALTH_CACHE_TTL = 5  # seconds
+
+
 def check_database_connection() -> bool:
-    """Check if database connection is healthy."""
+    """Check if database connection is healthy. Result is cached for 5 seconds."""
+    try:
+        cached = cache.get(_DB_HEALTH_CACHE_KEY)
+        if cached is not None:
+            return cached
+    except Exception:
+        pass
+
     try:
         with connection.cursor() as cursor:
             cursor.execute("SELECT 1")
-        return True
+        result = True
     except Exception as e:
         logger.error(f"Database connection check failed: {e}")
-        return False
+        result = False
+
+    try:
+        cache.set(_DB_HEALTH_CACHE_KEY, result, timeout=_DB_HEALTH_CACHE_TTL)
+    except Exception:
+        pass
+
+    return result
 
 
 def ensure_database_connection():
@@ -200,7 +218,8 @@ def admin_connection_monitor(request):
     """Monitor admin panel connections and provide status."""
     try:
         db_status = check_database_connection()
-        cache_status = cache.get('connection_test', 'test') == 'test'
+        cache.set('connection_test', 'ok', 10)
+        cache_status = cache.get('connection_test') == 'ok'
         
         return {
             'database': 'connected' if db_status else 'disconnected',

--- a/store/middleware.py
+++ b/store/middleware.py
@@ -34,38 +34,6 @@ class ConnectionResilienceMiddleware(MiddlewareMixin):
         )
     
     def process_request(self, request):
-        """Process incoming request and check connection health."""
-        # Skip connection check for static files and health checks
-        if (request.path.startswith('/static/') or 
-            request.path.startswith('/media/') or
-            request.path.startswith('/health/')):
-            return None
-        
-        # Check database connection
-        try:
-            if not check_database_connection():
-                logger.warning("Database connection lost, attempting reconnection")
-                ensure_database_connection()
-        except Exception as e:
-            logger.error(f"Failed to reconnect to database: {e}")
-            
-            # Handle different types of requests
-            if request.path.startswith('/admin/'):
-                messages.error(request, "Database connection lost. Please refresh the page.")
-            elif request.method == 'POST':
-                # For POST requests, save the data and return error
-                self._handle_post_connection_failure(request)
-                return JsonResponse({
-                    'error': 'Connection lost',
-                    'message': 'Your data has been saved. Please try again.',
-                    'retry_available': True
-                }, status=503)
-            else:
-                return JsonResponse({
-                    'error': 'Service temporarily unavailable',
-                    'message': 'Please try again in a moment'
-                }, status=503)
-        
         return None
     
     def process_response(self, request, response):
@@ -160,27 +128,6 @@ class AdminConnectionMonitorMiddleware(MiddlewareMixin):
     """
     
     def process_request(self, request):
-        """Monitor admin panel requests."""
-        if not request.path.startswith('/admin/'):
-            return None
-        
-        # Check connection status for admin requests
-        try:
-            db_connected = check_database_connection()
-            
-            if not db_connected:
-                logger.warning("Admin panel request with disconnected database")
-                
-                # Add warning message for admin users
-                if hasattr(request, 'user') and request.user.is_authenticated:
-                    messages.warning(
-                        request, 
-                        "Database connection lost. Some features may not work properly."
-                    )
-        
-        except Exception as e:
-            logger.error(f"Admin connection monitoring failed: {e}")
-        
         return None
     
     def process_response(self, request, response):


### PR DESCRIPTION
- store/connection_utils.py: check_database_connection() кешує результат 5 секунд → замість SELECT 1 на кожен запит — максимум 1 раз на 5 сек; admin_connection_monitor: виправлено логіку (cache.set + cache.get замість cache.get з default, що завжди повертав True)
- store/admin_utils.py: cache._cache.keys() (private LocMemCache API, падає з AttributeError на Redis) → cache.delete_pattern з LocMem fallback
- store/middleware.py: прибрано SELECT 1 з process_request двох middleware (ConnectionResilienceMiddleware, AdminConnectionMonitorMiddleware) — до 4 зайвих запитів на кожну сторінку адмінки
- shop/apps.py: прибрано clear_cache_on_startup — видаляв __pycache__/.pyc (Python їх одразу відтворює), не має відношення до Django cache; підключено shop.signals
- shop/signals.py: post_save сигнали для інвалідації кешу при зміні Category/SubCategory/Furniture/SeasonalSettings
- shop/management/commands/clear_cache.py: додано cache.clear() — тепер команда дійсно очищає Django cache (Redis/LocMem)