### PR TITLE
fix(price): recompute() читає base-is-on-sale з DOM при кожному виклику

### DIFF
--- a/static/js/furniture-detail-alt.js
+++ b/static/js/furniture-detail-alt.js
@@ -463,11 +463,13 @@ document.addEventListener('DOMContentLoaded', () => {
         stockLabel.textContent = targetText;
     }
 
-    const priceContainer = priceEl ? priceEl.parentElement : null;
-    const baseIsOnSale = priceContainer?.getAttribute('data-base-is-on-sale') === 'true';
-    const baseOriginalPrice = parseFloat(priceContainer?.getAttribute('data-base-original-price') || '0');
-
     function recompute() {
+        const priceContainer = priceEl ? priceEl.parentElement : null;
+        const baseIsOnSale = priceContainer?.getAttribute('data-base-is-on-sale') === 'true';
+        const baseOriginalPrice = parseFloat(
+            (priceContainer?.getAttribute('data-base-original-price') || '0').replace(/\s/g, '').replace(',', '.')
+        );
+
         let total = selectedPrice;
         let originalTotal = selectedPrice;
 


### PR DESCRIPTION
Попередній код визначав baseIsOnSale/baseOriginalPrice як const поза recompute() — TDZ-помилка при ранньому виклику через setCustomOptionSelection переривала весь DOMContentLoaded callback. Також додано нормалізацію locale-формату числа (пробіл + кома → крапка).