### PR TITLE
fix(price): showPromo без size-chip = isOnSale, без порівняння цін

### DIFF
--- a/static/js/furniture-detail-alt.js
+++ b/static/js/furniture-detail-alt.js
@@ -510,21 +510,22 @@ document.addEventListener('DOMContentLoaded', () => {
         originalTotal = originalTotal * q;
         
         if (priceEl) {
-            if (isOnSale && originalTotal > total) {
-                // Show promotional price and original price
+            const showPromo = selectedSizeChip
+                ? (isOnSale && originalTotal > total)
+                : isOnSale;
+            if (showPromo) {
                 priceEl.textContent = Math.round(total) + ' грн';
                 priceEl.className = 'text-3xl text-red-600 font-semibold';
-                
                 if (origEl) {
-                    origEl.textContent = Math.round(originalTotal) + ' грн';
+                    if (originalTotal > total) {
+                        origEl.textContent = Math.round(originalTotal) + ' грн';
+                    }
                     origEl.className = 'text-lg text-brown-500 line-through';
                     origEl.style.display = 'block';
                 }
             } else {
-                // Show regular price
                 priceEl.textContent = Math.round(total) + ' грн';
                 priceEl.className = 'text-3xl text-brown-800 font-semibold';
-                
                 if (origEl) {
                     origEl.style.display = 'none';
                 }


### PR DESCRIPTION
Для товарів без size-chip умова originalTotal > total могла давати false (якщо data-base-original-price не зчитувалась або дорівнювала selectedPrice). Тепер: без active size-chip — довіряємо data-base-is-on-sale напряму. З size-chip — порівняння збережено (chip може бути без акції). Якщо originalTotal не > total — не перезаписуємо origEl.textContent (залишаємо те що вже відрендерив template).